### PR TITLE
Hotfix/#20 한글 인코딩 문제 해결

### DIFF
--- a/src/main/java/org/example/odiya/map/service/MapService.java
+++ b/src/main/java/org/example/odiya/map/service/MapService.java
@@ -12,10 +12,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import static org.example.odiya.common.exception.type.ErrorType.REST_CLIENT_ERROR;

--- a/src/main/java/org/example/odiya/map/service/MapService.java
+++ b/src/main/java/org/example/odiya/map/service/MapService.java
@@ -12,6 +12,12 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import static org.example.odiya.common.exception.type.ErrorType.REST_CLIENT_ERROR;
 import static org.example.odiya.common.exception.type.ErrorType.SEARCH_RESULT_NOT_FOUND;
 
@@ -34,20 +40,21 @@ public class MapService {
     public MapSearchResponse searchByKeyword(String query) {
         try {
             HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
             headers.set("Authorization", "KakaoAK " + key);
 
             HttpEntity<String> entity = new HttpEntity<>(headers);
 
-            String url = UriComponentsBuilder
-                    .fromHttpUrl(host)
+            URI uri = UriComponentsBuilder
+                    .fromUriString(host)
                     .path(searchPath)
                     .queryParam("query", query)
-                    .build(false)
-                    .encode()
-                    .toString();
+                    .build()
+                    .encode(StandardCharsets.UTF_8)
+                    .toUri();
 
             ResponseEntity<MapSearchResponse> response = restTemplate.exchange(
-                    url,
+                    uri,
                     HttpMethod.GET,
                     entity,
                     MapSearchResponse.class


### PR DESCRIPTION
## Description
- 한글 인코딩 문제 해결
## Changes
### Service
- [x] MapService
## Additional context
- deprecated된 fromHttpUrl() 제거 후 fromUriString() 로 변경
- UriComponentsBuilder로 인코딩한 반환형을 URI로 변경
- UriComponentsBuilder.encode(StandardCharsets.UTF_8) 로 변경