### PR TITLE
Feature/#30 약속 시간이 현재시간보다 과거일 경우 스케쥴링 처리

### DIFF
--- a/src/main/java/org/example/odiya/common/config/SchedulerConfig.java
+++ b/src/main/java/org/example/odiya/common/config/SchedulerConfig.java
@@ -1,0 +1,25 @@
+package org.example.odiya.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Slf4j
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);  // 동시 실행 가능한 스케줄 작업 수
+        scheduler.setThreadNamePrefix("scheduled-task-");
+        scheduler.setErrorHandler(throwable ->
+                log.error("스케쥴러 작업 에러: ", throwable));
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        return scheduler;
+    }
+}

--- a/src/main/java/org/example/odiya/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/example/odiya/meeting/repository/MeetingRepository.java
@@ -2,10 +2,25 @@ package org.example.odiya.meeting.repository;
 
 import org.example.odiya.meeting.domain.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     Optional<Meeting> findByInviteCode(String inviteCode);
+
+    @Query("UPDATE Meeting m SET m.overdue = true " +
+            "WHERE m.overdue = false " +
+            "AND m.date <= :date " +  // 날짜 비교
+            "AND m.time <= :time")    // 시간 비교
+    @Modifying
+    int bulkUpdateOverdueStatus(
+            @Param("date") LocalDate date,
+            @Param("time") LocalTime time
+    );
 }

--- a/src/main/java/org/example/odiya/meeting/service/MeetingQueryService.java
+++ b/src/main/java/org/example/odiya/meeting/service/MeetingQueryService.java
@@ -7,6 +7,8 @@ import org.example.odiya.meeting.repository.MeetingRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static org.example.odiya.common.exception.type.ErrorType.MEETING_NOT_FOUND_ERROR;
 
 @Service
@@ -19,5 +21,9 @@ public class MeetingQueryService {
     public Meeting findMeetingByInviteCode(String inviteCode) {
         return meetingRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new NotFoundException(MEETING_NOT_FOUND_ERROR));
+    }
+
+    public int updateOverdueMeetings(LocalDateTime now) {
+        return meetingRepository.bulkUpdateOverdueStatus(now.toLocalDate(), now.toLocalTime());
     }
 }

--- a/src/main/java/org/example/odiya/meeting/utils/MeetingOverDueScheduler.java
+++ b/src/main/java/org/example/odiya/meeting/utils/MeetingOverDueScheduler.java
@@ -1,0 +1,25 @@
+package org.example.odiya.meeting.utils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.meeting.service.MeetingQueryService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MeetingOverDueScheduler {
+
+    private final MeetingQueryService meetingQueryService;
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void updateMeetingOverdueStatus() {
+        int updatedMeetingCount = meetingQueryService.updateOverdueMeetings(LocalDateTime.now());
+        log.info("Updated overdue status of {} meetings", updatedMeetingCount);
+    }
+}

--- a/src/test/java/org/example/odiya/OdiyaApplicationTests.java
+++ b/src/test/java/org/example/odiya/OdiyaApplicationTests.java
@@ -3,7 +3,6 @@ package org.example.odiya;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/org/example/odiya/meeting/repository/MeetingRepositoryTest.java
+++ b/src/test/java/org/example/odiya/meeting/repository/MeetingRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.example.odiya.meeting.repository;
 
+import jakarta.persistence.EntityManager;
 import org.example.odiya.meeting.domain.Meeting;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -7,6 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +21,9 @@ class MeetingRepositoryTest {
 
     @Autowired
     private MeetingRepository meetingRepository;
+
+    @Autowired
+    private EntityManager entityManager;
 
     private Meeting meeting;
 
@@ -34,5 +42,48 @@ class MeetingRepositoryTest {
         // Then
         assertThat(foundMeeting).isPresent();
         assertThat(foundMeeting.get().getInviteCode()).isEqualTo("123456");
+    }
+
+    @Test
+    @DisplayName("현재 시간보다 이전의 약속들이 만료 상태로 업데이트된다.")
+    void bulkUpdateOverdueStatus_Success() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = now.toLocalDate();
+        LocalTime currentTime = now.toLocalTime();
+
+        // 과거 미팅 (만료되어야 함)
+        Meeting pastMeeting = Meeting.builder()
+                .name("지난 모임")
+                .date(today.minusDays(1))
+                .time(currentTime)
+                .inviteCode("342122")
+                .overdue(false)
+                .build();
+
+        // 미래 미팅 (만료되지 않아야 함)
+        Meeting futureMeeting = Meeting.builder()
+                .name("앞으로의 모임")
+                .date(today.plusDays(1))
+                .time(currentTime)
+                .inviteCode("432512")
+                .overdue(false)
+                .build();
+
+        meetingRepository.saveAll(Arrays.asList(pastMeeting, futureMeeting));
+
+        // when
+        int updatedCount = meetingRepository.bulkUpdateOverdueStatus(today, currentTime);
+
+        // then
+        assertThat(updatedCount).isEqualTo(1);
+
+        entityManager.clear();
+
+        Meeting updatedPastMeeting = meetingRepository.findByInviteCode("342122").orElseThrow();
+        Meeting updatedFutureMeeting = meetingRepository.findByInviteCode("432512").orElseThrow();
+
+        assertThat(updatedPastMeeting.isOverdue()).isTrue();
+        assertThat(updatedFutureMeeting.isOverdue()).isFalse();
     }
 }

--- a/src/test/java/org/example/odiya/meeting/utils/MeetingOverDueSchedulerTest.java
+++ b/src/test/java/org/example/odiya/meeting/utils/MeetingOverDueSchedulerTest.java
@@ -1,0 +1,64 @@
+package org.example.odiya.meeting.utils;
+
+import org.example.odiya.meeting.service.MeetingQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.support.SimpleTriggerContext;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class MeetingOverDueSchedulerTest {
+
+    @MockBean
+    private MeetingQueryService meetingQueryService;
+
+    @Autowired
+    private MeetingOverDueScheduler scheduler;
+
+    @Test
+    @DisplayName("스케줄러가 실행되면 종료된 약속들이 업데이트된다.")
+    void updateMeetingOverdueStatus_Success() {
+        // given
+        when(meetingQueryService.updateOverdueMeetings(any(LocalDateTime.class)))
+                .thenReturn(3); // 3개의 미팅이 업데이트된다고 가정
+
+        // when
+        scheduler.updateMeetingOverdueStatus();
+
+        // then
+        verify(meetingQueryService).updateOverdueMeetings(any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러가 매시 정각에 실행된다.")
+    void checkSchedulerTiming() {
+        // given
+        CronTrigger trigger = new CronTrigger("0 0 * * * *");
+
+        // when
+        LocalDateTime now = LocalDateTime.now();
+        Date nextExecutionDate = trigger.nextExecutionTime(new SimpleTriggerContext());
+        LocalDateTime nextExecution = LocalDateTime.ofInstant(
+                nextExecutionDate.toInstant(),
+                ZoneId.systemDefault()
+        );
+
+        // then
+        // 다음 실행 시간이 다음 정각이어야 함
+        assertThat(nextExecution.getMinute()).isEqualTo(0);
+        assertThat(nextExecution.getSecond()).isEqualTo(0);
+        assertThat(nextExecution.isAfter(now)).isTrue();
+    }
+}

--- a/src/test/java/org/example/odiya/meeting/utils/MeetingOverDueSchedulerTest.java
+++ b/src/test/java/org/example/odiya/meeting/utils/MeetingOverDueSchedulerTest.java
@@ -3,9 +3,10 @@ package org.example.odiya.meeting.utils;
 import org.example.odiya.meeting.service.MeetingQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 
@@ -18,13 +19,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class MeetingOverDueSchedulerTest {
 
-    @MockBean
+    @Mock
     private MeetingQueryService meetingQueryService;
 
-    @Autowired
+    @InjectMocks
     private MeetingOverDueScheduler scheduler;
 
     @Test


### PR DESCRIPTION
## Description
- 약속 시간이 현재시간보다 과거일 경우 스케쥴링 처리
- overdue 값 true로 수정
## Changes
### Config
- [x] SchedulerConfig
### Repository
- [x] MeetingRepository
### Utils
- [x] MeetingOverDueScheduler
### Test
- [x] MeetingRepositoryTest
- [x] MeetingOverDueSchedulerTest
## Additional context
- JPQL을 사용한 벌크 업데이트를 통해 성능 개선
Closes #30 