### PR TITLE
Feature/#35 예상 도착시간 저장을 위한 엔티티 추가

### DIFF
--- a/src/main/java/org/example/odiya/common/constant/Constants.java
+++ b/src/main/java/org/example/odiya/common/constant/Constants.java
@@ -17,6 +17,6 @@ public class Constants {
             "/api/auth/**"
     };
 
-    public static final String MODE_WALKING = "walking";
+    public static final String MODE_TRANSIT = "transit";
     public static final String STATUS_OK = "OK";
 }

--- a/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
@@ -43,9 +43,13 @@ public enum ErrorType {
     // Meeting
     MEETING_NOT_FOUND_ERROR("MEETING_40400", "해당 약속을 찾을 수 없습니다."),
     MEETING_OVERDUE_ERROR("MEETING_40401", "해당 약속은 이미 종료되었습니다."),
+    NO_DATE_AND_TIME_ERROR("MEETING_40402", "설정된 약속 시간이 없습니다."),
 
     // Mate
     DUPLICATION_MATE_ERROR("MATE_40900", "해당 약속에 이미 참여한 멤버입니다."),
+
+    // Eta
+    ETA_NOT_FOUND_ERROR("ETA_40400", "약속 참여자의 ETA 상태를 찾을 수 없습니다."),
 
     // Route
     SEARCH_ROUTE_NOT_FOUND_ERROR("ROUTE_40400", "도보 경로를 찾을 수 없습니다."),

--- a/src/main/java/org/example/odiya/common/util/TimeUtil.java
+++ b/src/main/java/org/example/odiya/common/util/TimeUtil.java
@@ -1,0 +1,29 @@
+package org.example.odiya.common.util;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+
+public class TimeUtil {
+
+    private TimeUtil() {
+    }
+
+    private static final int ROUND_DIGITS = 0;
+
+    public static final ZoneOffset KST_OFFSET = ZoneOffset.ofHours(9);
+
+    public static LocalDateTime nowWithTrim() {
+        return trimSecondsAndNanos(LocalDateTime.now());
+    }
+
+    public static LocalDateTime trimSecondsAndNanos(LocalDateTime time) {
+        return time.withSecond(ROUND_DIGITS)
+                .withNano(ROUND_DIGITS);
+    }
+
+    public static LocalTime trimSecondsAndNanos(LocalTime time) {
+        return time.withSecond(ROUND_DIGITS)
+                .withNano(ROUND_DIGITS);
+    }
+}

--- a/src/main/java/org/example/odiya/eta/domain/Eta.java
+++ b/src/main/java/org/example/odiya/eta/domain/Eta.java
@@ -1,0 +1,37 @@
+package org.example.odiya.eta.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.odiya.common.domain.BaseEntity;
+import org.example.odiya.mate.domain.Mate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Eta extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "mate_id")
+    private Mate mate;
+
+    @Column(nullable = false)
+    private long remainingMinutes;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isArrived = false;
+
+    public void updateRemainingMinutes(long remainingMinutes) {
+        this.remainingMinutes = remainingMinutes;
+    }
+
+    public void markAsArrived() {
+        this.isArrived = true;
+    }
+}

--- a/src/main/java/org/example/odiya/eta/domain/EtaStatus.java
+++ b/src/main/java/org/example/odiya/eta/domain/EtaStatus.java
@@ -1,0 +1,42 @@
+package org.example.odiya.eta.domain;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.common.exception.NotFoundException;
+import org.example.odiya.meeting.domain.Meeting;
+
+import java.util.Arrays;
+import java.util.function.BiPredicate;
+
+import static org.example.odiya.common.exception.type.ErrorType.ETA_NOT_FOUND_ERROR;
+
+@Slf4j
+@Getter
+public enum EtaStatus {
+    MISSING((eta, meeting) -> eta.isMissing()),
+    ARRIVED((eta, meeting) -> eta.isArrived()),
+    ARRIVAL_SOON((eta, meeting) -> eta.isArrivalSoon(meeting) && !meeting.isEnd()),
+    LATE((eta, meeting) -> !eta.isArrivalSoon(meeting) && meeting.isEnd());
+
+    private final BiPredicate<Eta, Meeting> condition;
+
+    EtaStatus(BiPredicate<Eta, Meeting> condition) {
+        this.condition = condition;
+    }
+
+    public static EtaStatus of(Eta eta, Meeting meeting) {
+        EtaStatus etaStatus = Arrays.stream(values())
+                .filter(status -> status.condition.test(eta, meeting))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ETA_NOT_FOUND_ERROR));
+
+        if (etaStatus == EtaStatus.LATE) {
+            log.info("[report_LATE_MATE] mate_id: {}, member_id: {}, meeting_id: {}",
+                    eta.getMate().getId(),
+                    eta.getMate().getMember().getId(),
+                    meeting.getId()
+            );
+        }
+        return etaStatus;
+    }
+}

--- a/src/main/java/org/example/odiya/eta/domain/TransportType.java
+++ b/src/main/java/org/example/odiya/eta/domain/TransportType.java
@@ -1,0 +1,6 @@
+package org.example.odiya.eta.domain;
+
+public enum TransportType {
+    WALKING,
+    TRANSIT,
+}

--- a/src/main/java/org/example/odiya/eta/dto/request/EtaRequest.java
+++ b/src/main/java/org/example/odiya/eta/dto/request/EtaRequest.java
@@ -1,0 +1,24 @@
+package org.example.odiya.eta.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EtaRequest {
+
+    @Schema(description = "위치추적 불가 여부", example = "false")
+    @NotNull
+    private boolean isMissing;
+
+    @Schema(description = "현재 위도", example = "39.123345")
+    @NotNull
+    private String currentLatitude;
+
+    @Schema(description = "현재 경도", example = "126.234524")
+    @NotNull
+    private String currentLongitude;
+}

--- a/src/main/java/org/example/odiya/eta/repository/EtaRepository.java
+++ b/src/main/java/org/example/odiya/eta/repository/EtaRepository.java
@@ -1,0 +1,10 @@
+package org.example.odiya.eta.repository;
+
+import org.example.odiya.eta.domain.Eta;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EtaRepository extends JpaRepository<Eta, Long> {
+    Optional<Eta> findByMateId(Long mateId);
+}

--- a/src/main/java/org/example/odiya/eta/service/EtaQueryService.java
+++ b/src/main/java/org/example/odiya/eta/service/EtaQueryService.java
@@ -1,0 +1,15 @@
+package org.example.odiya.eta.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.odiya.eta.repository.EtaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EtaQueryService {
+
+    private final EtaRepository etaRepository;
+
+}

--- a/src/main/java/org/example/odiya/eta/service/EtaService.java
+++ b/src/main/java/org/example/odiya/eta/service/EtaService.java
@@ -1,0 +1,22 @@
+package org.example.odiya.eta.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.odiya.eta.domain.Eta;
+import org.example.odiya.eta.domain.TransportType;
+import org.example.odiya.eta.repository.EtaRepository;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.route.domain.RouteTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EtaService {
+
+    private final EtaRepository etaRepository;
+
+    @Transactional
+    public Eta saveFirstEtaOfMate(Mate mate, RouteTime routeTime, TransportType type) {
+        return etaRepository.save(new Eta(mate, routeTime.getMinutes(), type));
+    }
+}

--- a/src/main/java/org/example/odiya/meeting/domain/Meeting.java
+++ b/src/main/java/org/example/odiya/meeting/domain/Meeting.java
@@ -36,7 +36,6 @@ public class Meeting extends BaseEntity {
     private LocalDate date;
 
     @Column
-    @NotNull
     private LocalTime time;
 
     @Column(columnDefinition = "CHAR(6)", unique = true)

--- a/src/main/java/org/example/odiya/meeting/domain/Meeting.java
+++ b/src/main/java/org/example/odiya/meeting/domain/Meeting.java
@@ -49,6 +49,9 @@ public class Meeting extends BaseEntity {
     @OneToMany(mappedBy = "meeting")
     private List<Mate> mates = new ArrayList<>();
 
+    public Meeting(String name, LocalDate date, LocalTime time, Location target) {
+        this(null, name, target, date, TimeUtil.trimSecondsAndNanos(time), null, false, null);
+    }
 
     // 6자리 숫자로 구성된 초대 코드를 생성
     public void generateInviteCode() {

--- a/src/main/java/org/example/odiya/meeting/domain/Meeting.java
+++ b/src/main/java/org/example/odiya/meeting/domain/Meeting.java
@@ -1,12 +1,15 @@
 package org.example.odiya.meeting.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.example.odiya.common.domain.BaseEntity;
+import org.example.odiya.common.util.TimeUtil;
 import org.example.odiya.mate.domain.Mate;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,9 +32,11 @@ public class Meeting extends BaseEntity {
     private Location target;
 
     @Column
+    @NotNull
     private LocalDate date;
 
     @Column
+    @NotNull
     private LocalTime time;
 
     @Column(columnDefinition = "CHAR(6)", unique = true)
@@ -45,8 +50,17 @@ public class Meeting extends BaseEntity {
     @OneToMany(mappedBy = "meeting")
     private List<Mate> mates = new ArrayList<>();
 
+
     // 6자리 숫자로 구성된 초대 코드를 생성
     public void generateInviteCode() {
         this.inviteCode = RandomStringUtils.randomNumeric(6);
+    }
+
+    public boolean isEnd() {
+        return LocalDateTime.now().isAfter(LocalDateTime.of(date, time));
+    }
+
+    public LocalDateTime getMeetingTime() {
+        return TimeUtil.trimSecondsAndNanos(LocalDateTime.of(date, time));
     }
 }

--- a/src/main/java/org/example/odiya/meeting/domain/Meeting.java
+++ b/src/main/java/org/example/odiya/meeting/domain/Meeting.java
@@ -32,7 +32,6 @@ public class Meeting extends BaseEntity {
     private Location target;
 
     @Column
-    @NotNull
     private LocalDate date;
 
     @Column

--- a/src/main/java/org/example/odiya/route/service/GoogleRouteClient.java
+++ b/src/main/java/org/example/odiya/route/service/GoogleRouteClient.java
@@ -16,7 +16,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.Duration;
 
-import static org.example.odiya.common.constant.Constants.MODE_WALKING;
+import static org.example.odiya.common.constant.Constants.MODE_TRANSIT;
 import static org.example.odiya.common.constant.Constants.STATUS_OK;
 import static org.example.odiya.common.exception.type.ErrorType.*;
 
@@ -37,7 +37,7 @@ public class GoogleRouteClient implements RouteClient {
         return UriComponentsBuilder.fromHttpUrl(properties.getUrl())
                 .queryParam("origin", formatCoordinate(origin))
                 .queryParam("destination", formatCoordinate(target))
-                .queryParam("mode", MODE_WALKING)
+                .queryParam("mode", MODE_TRANSIT)
                 .queryParam("key", properties.getKey())
                 .build()
                 .toUriString();


### PR DESCRIPTION
## Description
- 약속에 참가한 멤버의 예상 도착시간 저장을 위한 엔티티 추가
- 약속장소에 도착했는지(boolean), 남은 예상시간(long) 을 필드로 선언, 저장한다. 
## Changes
### Domain
- [x] Eta
- [x] EtaStatus
- [x] TransportType
### Repository
- [x] EtaRepository
### Util
- [x] TimeUtil
## Additional context
- 예상 도착시간 저장과 함께 어떤 방식으로 오는지(대중교통 or 도보) 저장하기 위한 TransportType 추가
Closes #35 