### PR TITLE
Feature/#47 개발환경 DB MySQL 로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'


### PR DESCRIPTION
## Description
- 개발환경 DB MySQL 로 변경
## Changes
- [x] build.gradle
- [x] application-dev.yml
## Additional context
- 개발환경에서 사용했던 H2 데이터베이스 대신 MySQL 을 Docker로 띄워 사용한다.
- 테스트환경에선 H2 데이터베이스 사용한다.
Closes #47 