### PR TITLE
Feature/#49, #51 Eta 업데이트 로직 성능 개선

### DIFF
--- a/src/main/java/org/example/odiya/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/odiya/common/config/AsyncConfig.java
@@ -1,0 +1,45 @@
+package org.example.odiya.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.client.RestClientException;
+
+import java.util.Arrays;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Slf4j
+@EnableAsync
+@Configuration
+@EnableAspectJAutoProxy(exposeProxy = true)
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(6);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("EtaAsync-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> {
+            log.error("Async method {} threw exception: ", method.getName(), ex);
+            log.error("Parameters: {}", Arrays.toString(params));
+
+            if (ex instanceof RestClientException) {
+                log.error("External API call failed in async execution");
+            }
+        };
+    }
+}

--- a/src/main/java/org/example/odiya/eta/dto/response/EtaUpdateResult.java
+++ b/src/main/java/org/example/odiya/eta/dto/response/EtaUpdateResult.java
@@ -1,0 +1,10 @@
+package org.example.odiya.eta.dto.response;
+
+import org.example.odiya.eta.domain.Eta;
+
+public record EtaUpdateResult(
+          Eta eta,
+          long remainingMinutes,
+          boolean isFailed
+) {
+}

--- a/src/main/java/org/example/odiya/eta/repository/EtaRepository.java
+++ b/src/main/java/org/example/odiya/eta/repository/EtaRepository.java
@@ -2,9 +2,15 @@ package org.example.odiya.eta.repository;
 
 import org.example.odiya.eta.domain.Eta;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EtaRepository extends JpaRepository<Eta, Long> {
     Optional<Eta> findByMateId(Long mateId);
+
+    @Query("SELECT e FROM Eta e JOIN FETCH e.mate m WHERE m.meeting.id = :meetingId")
+    List<Eta> findAllByMeetingIdWithMate(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/org/example/odiya/eta/service/EtaQueryService.java
+++ b/src/main/java/org/example/odiya/eta/service/EtaQueryService.java
@@ -7,6 +7,8 @@ import org.example.odiya.eta.repository.EtaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.example.odiya.common.exception.type.ErrorType.MATE_ETA_NOT_FOUND_ERROR;
 
 @Service
@@ -19,5 +21,9 @@ public class EtaQueryService {
     public Eta findByMateId(Long mateId) {
         return etaRepository.findByMateId(mateId)
                 .orElseThrow(() -> new NotFoundException(MATE_ETA_NOT_FOUND_ERROR));
+    }
+
+    public List<Eta> findAllByMeetingIdWithMate(Long meetingId) {
+        return etaRepository.findAllByMeetingIdWithMate(meetingId);
     }
 }

--- a/src/main/java/org/example/odiya/eta/service/EtaService.java
+++ b/src/main/java/org/example/odiya/eta/service/EtaService.java
@@ -69,7 +69,7 @@ public class EtaService {
 
     public List<Eta> filterUpdatableEtas(List<Eta> etas) {
         return etas.stream()
-                .filter(eta -> !eta.isArrived() && !eta.isMissing())
+                .filter(eta -> !eta.isArrived())
                 .toList();
     }
 

--- a/src/main/java/org/example/odiya/meeting/controller/MeetingController.java
+++ b/src/main/java/org/example/odiya/meeting/controller/MeetingController.java
@@ -59,7 +59,7 @@ public class MeetingController {
     public ResponseEntity<Void> updateMeetingEta(
             @AuthMember Member member,
             @PathVariable("id") Long meetingId) {
-        etaService.updateEtaOfMate(meetingId, member.getId());
+        meetingService.updateEtaForMeetingMates(meetingId, member.getId());
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .build();

--- a/src/main/java/org/example/odiya/meeting/service/MeetingService.java
+++ b/src/main/java/org/example/odiya/meeting/service/MeetingService.java
@@ -1,6 +1,12 @@
 package org.example.odiya.meeting.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.common.exception.BadRequestException;
+import org.example.odiya.eta.domain.Eta;
+import org.example.odiya.eta.dto.response.EtaUpdateResult;
+import org.example.odiya.eta.service.EtaQueryService;
+import org.example.odiya.eta.service.EtaService;
 import org.example.odiya.mate.service.MateQueryService;
 import org.example.odiya.mate.service.MateService;
 import org.example.odiya.meeting.domain.Coordinates;
@@ -12,11 +18,18 @@ import org.example.odiya.meeting.dto.response.MeetingDetailResponse;
 import org.example.odiya.meeting.dto.response.MeetingListResponse;
 import org.example.odiya.meeting.repository.MeetingRepository;
 import org.example.odiya.member.domain.Member;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
+import static org.example.odiya.common.exception.type.ErrorType.MEETING_OVERDUE_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.NOT_ONE_HOUR_BEFORE_MEETING_ERROR;
+
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -24,8 +37,10 @@ public class MeetingService {
 
     private final MeetingRepository meetingRepository;
     private final MeetingQueryService meetingQueryService;
-    private final MateService mateService;
     private final MateQueryService mateQueryService;
+    private final EtaQueryService etaQueryService;
+    private final MateService mateService;
+    private final EtaService etaService;
 
     public MeetingCreateResponse createMeeting(Member member, MeetingCreateRequest request) {
         Location targetLocation = new Location(
@@ -58,12 +73,49 @@ public class MeetingService {
     public MeetingListResponse getMyMeetingList(Member member) {
         int mateCount = mateQueryService.countByMeetingId(member.getId());
         List<Meeting> meetingList = meetingQueryService.findOverdueMeetings(member.getId());
-        return MeetingListResponse.of(meetingList,mateCount);
+        return MeetingListResponse.of(meetingList, mateCount);
     }
 
     public MeetingDetailResponse getMeetingDetail(Member member, Long meetingId) {
         Meeting meeting = meetingQueryService.findById(meetingId);
         mateQueryService.validateMateExists(member.getId(), meetingId);
         return MeetingDetailResponse.from(meeting);
+    }
+
+    public void updateEtaForMeetingMates(Long meetingId, Long memberId) {
+        Meeting meeting = meetingQueryService.findById(meetingId);
+        mateQueryService.validateMateExists(meetingId, memberId);
+        validateMeetingStatus(meeting);
+
+        List<Eta> etas = etaQueryService.findAllByMeetingIdWithMate(meetingId);
+        // 업데이트가 필요한 Eta들만 필터링
+        List<Eta> etasToUpdate = etaService.filterUpdatableEtas(etas);
+
+        // 비동기로 경로 계산 및 상태 업데이트
+        updateEtasAsync(etasToUpdate, meeting);
+    }
+
+    @Async
+    protected void updateEtasAsync(List<Eta> etas, Meeting meeting) {
+        List<CompletableFuture<EtaUpdateResult>> futures = etas.stream()
+                .map(eta -> etaService.calculateEtaAsync(eta, meeting))
+                .toList();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenRun(() -> etaService.saveEtaUpdates(futures));
+    }
+
+    private void validateMeetingStatus(Meeting meeting) {
+        if (meeting.isOverdue()) {
+            throw new BadRequestException(MEETING_OVERDUE_ERROR);
+        }
+        verifyAnHourBeforeMeetingTime(meeting);
+    }
+
+    private void verifyAnHourBeforeMeetingTime(Meeting meeting) {
+        LocalDateTime meetingTime = meeting.getMeetingTime();
+        if (LocalDateTime.now().isBefore(meetingTime.minusHours(1))) {
+            throw new BadRequestException(NOT_ONE_HOUR_BEFORE_MEETING_ERROR);
+        }
     }
 }


### PR DESCRIPTION
## Description
- Eta 업데이트 로직 성능 개선과 참여자 도착, 행방불명 상태 업데이트 기능 구현
- 현재의 방식은 각 Mate 마다 경로을 순차적으로 계산하였다. (Mate 5명일 경우 외부 API 호출시간이 1초라한다면 총 5초가 걸린다.) 따라서 비동기 처리를 통해 모든 Mate 의 경로 계산이 동시에 들어가게한다.
- 외부 API 호출은 트랜잭션에서 분리하여 DB 저장만 트랜잭션 처리한다. 따라서 한명의 Mate의 경로 계산 실패가 다른 Mate들에게 영향을 미치지 않게한다.
## Changes
### Config
- [x] AsyncConfig
### Service
- [x] EtaService
- [x] MeetingService
## Additional context
- @Async 가 붙은 updateEtasAsync메서드에서 Eta 업데이트 로직을 호출할 때, 이러한 경고 메세지가 발생되었다.
`@Transactional self-invocation (in effect, a method within the target object calling another method of the target object) does not lead to an actual transaction at runtime`
- Spring의 @Transactional은 프록시 기반으로 동작하는데, 같은 클래스 내부에서 메서드를 호출할 때는 프록시를 거치지 않고 직접 호출되어 트랜잭션이 적용되지 않는다는 경고였다.
- 해결방법으로는 두 메서드가 각각 다른 클래스에 존재하거나, TransactionTemplate 로 트랜잭션을 통제해야하는데, 나는 전자의 방법을 택하여 Eta 저장 및 업데이트 로직의 메서드는 EtaService 에, Meeting 관련 검증 메서드와 updateEtaForMeetingMates() 는 MeetingService 에 두어 책임 분리를 명확하게 함과 동시에 문제 해결했다.
- 보통 이 서비스를 이용할 때 약속의 경우 1명, 2명인 경우는 거의 없고, 4명 이상인 경우가 대부분일 것이다. 따라서 AsyncConfig 의 기본 쓰레드 풀 사이즈를 최소 6 최대 10으로 설정한 뒤 대기큐 크기를 20으로 해두어 동시에 30개의 요청을 처리할 수 있도록 설정해두었다.
Closes #49 
Closes #51 