### PR TITLE
Feature/#57 이벤트별 푸시 알림 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,6 @@ jobs:
         ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       run: ./gradlew test --info --stacktrace -Dspring.profiles.active=test
-
-    - name: 🐳 테스트 로그 수집
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-logs
-        path: build/reports/tests/
       
     - name: 🐳 테스트 결과 Report
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: 🐳 JDK 17 세팅
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: 🐳 gradlew 실행 권한 설정
@@ -30,7 +30,7 @@ jobs:
         KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
         ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-      run: ./gradlew --info test -Dspring.profiles.active=test
+      run: ./gradlew test --info --stacktrace -Dspring.profiles.active=test
       
     - name: 🐳 테스트 결과 Report
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
         ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       run: ./gradlew test --info --stacktrace -Dspring.profiles.active=test
+
+    - name: 🐳 테스트 로그 수집
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-logs
+        path: build/reports/tests/
       
     - name: 🐳 테스트 결과 Report
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 
     // H2
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/org/example/odiya/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/odiya/common/config/AsyncConfig.java
@@ -2,6 +2,7 @@ package org.example.odiya.common.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
@@ -27,6 +28,17 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setQueueCapacity(20);
         executor.setThreadNamePrefix("EtaAsync-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "fcmExecutor")
+    public Executor fcmAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("FcmAsync-");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/org/example/odiya/common/config/SchedulerConfig.java
+++ b/src/main/java/org/example/odiya/common/config/SchedulerConfig.java
@@ -3,6 +3,7 @@ package org.example.odiya.common.config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -12,6 +13,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @EnableScheduling
 public class SchedulerConfig {
 
+    @Primary
     @Bean
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();

--- a/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
@@ -43,7 +43,7 @@ public enum ErrorType {
     MEETING_NOT_FOUND_ERROR("MEETING_40400", "해당 약속을 찾을 수 없습니다."),
     MEETING_OVERDUE_ERROR("MEETING_40401", "해당 약속은 이미 종료되었습니다."),
     NO_DATE_AND_TIME_ERROR("MEETING_40402", "설정된 약속 시간이 없습니다."),
-    NOT_ONE_HOUR_BEFORE_MEETING_ERROR("MEETING_40000", "설정된 약속 시간보다 1시간 전이 아닙니다."),
+    NOT_ONE_HOUR_BEFORE_MEETING_ERROR("MEETING_40000", "현재 시간이 설정된 약속 시간 1시간 전보다 이전입니다."),
     NOT_SAME_MEETING_ERROR("MEETING_40001", "재촉한 참여자와 재촉 당한 참여자가 같은 약속에 속해있지 않습니다."),
 
     // Mate

--- a/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
@@ -52,6 +52,9 @@ public enum ErrorType {
     // Eta
     MATE_ETA_NOT_FOUND_ERROR("ETA_40400", "약속 참여자의 ETA 상태를 찾을 수 없습니다."),
 
+    // Notification
+    NOTIFICATION_NOT_FOUND_ERROR("NOTIFICATION_40400", "해당 알림을 찾을 수 없습니다."),
+
     // Route
     SEARCH_ROUTE_NOT_FOUND_ERROR("ROUTE_40400", "경로를 찾을 수 없습니다."),
     INVALID_ROUTE_REQUEST_ERROR("ROUTE_40000", "경로 요청이 잘못되었습니다."),
@@ -61,9 +64,12 @@ public enum ErrorType {
     INTERNAL_SERVER_ERROR("INTERNAL_50000", "서버 내부 에러입니다."),
     EXTERNAL_API_ERROR("INTERNAL_50001", "외부 API 호출 에러입니다."),
     REST_TEMPLATE_ERROR("INTERNAL_50002", "RestTemplate 에러입니다."),
-    TOO_MANY_REQUEST_ERROR("INTERNAL_50002", "API 호출 한도를 초과했습니다."),
-    FIREBASE_INIT_ERROR("INTERNAL_50003", "Firebase 초기화 에러입니다."),
-    FILE_PROCESS_ERROR("INTERNAL_50004", "파일 처리 중 에러가 발생했습니다."),
+    TOO_MANY_REQUEST_ERROR("INTERNAL_50003", "API 호출 한도를 초과했습니다."),
+    FIREBASE_INIT_ERROR("INTERNAL_50004", "Firebase 초기화 에러입니다."),
+    FILE_PROCESS_ERROR("INTERNAL_50005", "파일 처리 중 에러가 발생했습니다."),
+    FIREBASE_SUBSCRIBE_ERROR("INTERNAL_50006", "Firebase Subscribe 중 에러가 발생했습니다."),
+    FIREBASE_UNSUBSCRIBE_ERROR("INTERNAL_50007", "Firebase Unsubscribe 중 에러가 발생했습니다."),
+    FIREBASE_SEND_ERROR("INTERNAL_50008", "Firebase Send 중 에러가 발생했습니다."),
 
     // Validation
     NOT_NULL_VALID_ERROR("VALID_90000", "필수값이 누락되었습니다."),

--- a/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
@@ -44,10 +44,13 @@ public enum ErrorType {
     MEETING_OVERDUE_ERROR("MEETING_40401", "해당 약속은 이미 종료되었습니다."),
     NO_DATE_AND_TIME_ERROR("MEETING_40402", "설정된 약속 시간이 없습니다."),
     NOT_ONE_HOUR_BEFORE_MEETING_ERROR("MEETING_40000", "설정된 약속 시간보다 1시간 전이 아닙니다."),
+    NOT_SAME_MEETING_ERROR("MEETING_40001", "재촉한 참여자와 재촉 당한 참여자가 같은 약속에 속해있지 않습니다."),
 
     // Mate
     DUPLICATION_MATE_ERROR("MATE_40900", "해당 약속에 이미 참여한 멤버입니다."),
-    NOT_PARTICIPATED_MATE_ERROR("MATE_40400", "해당 약속에 참여하지 않았습니다."),
+    NOT_PARTICIPATED_MATE_ERROR("MATE_40300", "해당 약속에 참여하지 않았습니다."),
+    MATE_NOT_FOUND_ERROR("MATE_40400", "해당 약속 참여자를 찾을 수 없습니다."),
+    NOT_LATE_MATE_ERROR("MATE_40000", "해당 약속 참여자는 지각상태가 아닙니다."),
 
     // Eta
     MATE_ETA_NOT_FOUND_ERROR("ETA_40400", "약속 참여자의 ETA 상태를 찾을 수 없습니다."),

--- a/src/main/java/org/example/odiya/mate/dto/request/HurryUpRequest.java
+++ b/src/main/java/org/example/odiya/mate/dto/request/HurryUpRequest.java
@@ -1,0 +1,16 @@
+package org.example.odiya.mate.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HurryUpRequest {
+
+    @Schema(description = "재촉한 사람", example = "1")
+    private long senderId;
+
+    @Schema(description = "재촉 당한 사람", example = "2")
+    private long receiverId;
+}

--- a/src/main/java/org/example/odiya/mate/service/MateQueryService.java
+++ b/src/main/java/org/example/odiya/mate/service/MateQueryService.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.example.odiya.common.exception.ConflictException;
 import org.example.odiya.common.exception.ForbiddenException;
 import org.example.odiya.common.exception.NotFoundException;
+import org.example.odiya.mate.domain.Mate;
 import org.example.odiya.mate.repository.MateRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.example.odiya.common.exception.type.ErrorType.DUPLICATION_MATE_ERROR;
-import static org.example.odiya.common.exception.type.ErrorType.NOT_PARTICIPATED_MATE_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -17,6 +17,11 @@ import static org.example.odiya.common.exception.type.ErrorType.NOT_PARTICIPATED
 public class MateQueryService {
 
     private final MateRepository mateRepository;
+
+    public Mate findById(Long mateId) {
+        return mateRepository.findById(mateId)
+                .orElseThrow(() -> new NotFoundException(MATE_NOT_FOUND_ERROR));
+    }
 
     public void validateMateNotExists(Long memberId, Long meetingId) {
         if (mateRepository.existsByMemberIdAndMeetingId(memberId, meetingId)) {

--- a/src/main/java/org/example/odiya/mate/service/MateService.java
+++ b/src/main/java/org/example/odiya/mate/service/MateService.java
@@ -97,24 +97,32 @@ public class MateService {
     public void HurryUpMate(HurryUpRequest request) {
         Mate sender = mateQueryService.findById(request.getSenderId());
         Mate receiver = mateQueryService.findById(request.getReceiverId());
-        validateMateCondition(sender, receiver);
+        validateMateStatus(sender, receiver);
 
         Meeting meeting = meetingQueryService.findById(sender.getMeeting().getId());
-        if (meeting.checkAnHourBeforeMeetingTime()) {
-            throw new BadRequestException(NOT_ONE_HOUR_BEFORE_MEETING_ERROR);
-        }
+        validateMeetingStatus(meeting);
 
         HurryUpNotification hurryUpNotification = new HurryUpNotification(receiver);
         notificationService.sendHurryUpNotification(sender, hurryUpNotification);
     }
 
-    private void validateMateCondition(Mate sender, Mate receiver) {
+    private void validateMateStatus(Mate sender, Mate receiver) {
         if (!sender.getMeeting().getId().equals(receiver.getMeeting().getId())) {
             throw new BadRequestException(NOT_SAME_MEETING_ERROR);
         }
 
         if (!validateLateMate(receiver)) {
             throw new BadRequestException(NOT_LATE_MATE_ERROR);
+        }
+    }
+
+    private void validateMeetingStatus(Meeting meeting) {
+        if (meeting.isOverdue()) {
+            throw new BadRequestException(MEETING_OVERDUE_ERROR);
+        }
+
+        if (meeting.isBeforeOneHourMeetingTime()) {
+            throw new BadRequestException(NOT_ONE_HOUR_BEFORE_MEETING_ERROR);
         }
     }
 

--- a/src/main/java/org/example/odiya/mate/service/MateService.java
+++ b/src/main/java/org/example/odiya/mate/service/MateService.java
@@ -2,8 +2,10 @@ package org.example.odiya.mate.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.odiya.common.exception.BadRequestException;
+import org.example.odiya.eta.domain.EtaStatus;
 import org.example.odiya.eta.service.EtaService;
 import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.mate.dto.request.HurryUpRequest;
 import org.example.odiya.mate.dto.request.MateJoinRequest;
 import org.example.odiya.mate.dto.response.MateJoinResponse;
 import org.example.odiya.mate.repository.MateRepository;
@@ -12,11 +14,16 @@ import org.example.odiya.meeting.domain.Location;
 import org.example.odiya.meeting.domain.Meeting;
 import org.example.odiya.meeting.service.MeetingQueryService;
 import org.example.odiya.member.domain.Member;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.example.odiya.notification.domain.types.EntryNotification;
+import org.example.odiya.notification.domain.types.HurryUpNotification;
+import org.example.odiya.notification.domain.types.ReminderNotification;
+import org.example.odiya.notification.service.NotificationService;
 import org.example.odiya.route.service.RouteService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.example.odiya.common.exception.type.ErrorType.MEETING_OVERDUE_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.*;
 
 @Service
 @Transactional
@@ -28,6 +35,7 @@ public class MateService {
     private final MeetingQueryService meetingQueryService;
     private final RouteService routeService;
     private final EtaService etaService;
+    private final NotificationService notificationService;
 
     public MateJoinResponse joinMeeting(Member member, MateJoinRequest request) {
         // inviteCode 로 약속 찾기
@@ -70,5 +78,48 @@ public class MateService {
 
         Mate savedMate = mateRepository.save(mate);
         etaService.saveFirstEtaOfMate(savedMate, estimatedTime);
+
+        FcmTopic fcmTopic = new FcmTopic(meeting);
+
+        // 약속 토픽 구독
+        notificationService.subscribeTopic(member.getDeviceToken(), fcmTopic);
+
+        // 약속 참가 알림 스케줄링
+        EntryNotification entryNotification = new EntryNotification(savedMate, fcmTopic);
+        notificationService.saveAndScheduleNotification(entryNotification.toNotification());
+
+        // 약속 리마인더 알림 스케줄링
+        ReminderNotification reminderNotification = new ReminderNotification(meeting, savedMate, fcmTopic);
+        notificationService.saveAndScheduleNotification(reminderNotification.toNotification());
+    }
+
+    @Transactional
+    public void HurryUpMate(HurryUpRequest request) {
+        Mate sender = mateQueryService.findById(request.getSenderId());
+        Mate receiver = mateQueryService.findById(request.getReceiverId());
+        validateMateCondition(sender, receiver);
+
+        Meeting meeting = meetingQueryService.findById(sender.getMeeting().getId());
+        if (meeting.checkAnHourBeforeMeetingTime()) {
+            throw new BadRequestException(NOT_ONE_HOUR_BEFORE_MEETING_ERROR);
+        }
+
+        HurryUpNotification hurryUpNotification = new HurryUpNotification(receiver);
+        notificationService.sendHurryUpNotification(sender, hurryUpNotification);
+    }
+
+    private void validateMateCondition(Mate sender, Mate receiver) {
+        if (!sender.getMeeting().getId().equals(receiver.getMeeting().getId())) {
+            throw new BadRequestException(NOT_SAME_MEETING_ERROR);
+        }
+
+        if (!validateLateMate(receiver)) {
+            throw new BadRequestException(NOT_LATE_MATE_ERROR);
+        }
+    }
+
+    private boolean validateLateMate(Mate receiver) {
+        EtaStatus etaStatus = etaService.findEtaStatus(receiver);
+        return etaStatus == EtaStatus.LATE;
     }
 }

--- a/src/main/java/org/example/odiya/meeting/domain/Meeting.java
+++ b/src/main/java/org/example/odiya/meeting/domain/Meeting.java
@@ -81,7 +81,7 @@ public class Meeting extends BaseEntity {
         return target.getCoordinates();
     }
 
-    public boolean checkAnHourBeforeMeetingTime() {
-        return !LocalDateTime.now().isBefore(getMeetingTime().minusHours(1));
+    public boolean isBeforeOneHourMeetingTime() {
+        return LocalDateTime.now().isBefore(getMeetingTime().minusHours(1));
     }
 }

--- a/src/main/java/org/example/odiya/meeting/domain/Meeting.java
+++ b/src/main/java/org/example/odiya/meeting/domain/Meeting.java
@@ -80,4 +80,8 @@ public class Meeting extends BaseEntity {
     public Coordinates getTargetCoordinates() {
         return target.getCoordinates();
     }
+
+    public boolean checkAnHourBeforeMeetingTime() {
+        return !LocalDateTime.now().isBefore(getMeetingTime().minusHours(1));
+    }
 }

--- a/src/main/java/org/example/odiya/meeting/service/MeetingService.java
+++ b/src/main/java/org/example/odiya/meeting/service/MeetingService.java
@@ -109,7 +109,7 @@ public class MeetingService {
             throw new BadRequestException(MEETING_OVERDUE_ERROR);
         }
 
-        if (meeting.checkAnHourBeforeMeetingTime()) {
+        if (meeting.isBeforeOneHourMeetingTime()) {
             throw new BadRequestException(NOT_ONE_HOUR_BEFORE_MEETING_ERROR);
         }
     }

--- a/src/main/java/org/example/odiya/meeting/service/MeetingService.java
+++ b/src/main/java/org/example/odiya/meeting/service/MeetingService.java
@@ -22,7 +22,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -109,12 +108,8 @@ public class MeetingService {
         if (meeting.isOverdue()) {
             throw new BadRequestException(MEETING_OVERDUE_ERROR);
         }
-        verifyAnHourBeforeMeetingTime(meeting);
-    }
 
-    private void verifyAnHourBeforeMeetingTime(Meeting meeting) {
-        LocalDateTime meetingTime = meeting.getMeetingTime();
-        if (LocalDateTime.now().isBefore(meetingTime.minusHours(1))) {
+        if (meeting.checkAnHourBeforeMeetingTime()) {
             throw new BadRequestException(NOT_ONE_HOUR_BEFORE_MEETING_ERROR);
         }
     }

--- a/src/main/java/org/example/odiya/notification/domain/FcmTopic.java
+++ b/src/main/java/org/example/odiya/notification/domain/FcmTopic.java
@@ -5,12 +5,50 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.odiya.meeting.domain.Meeting;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmTopic {
 
+    private static final String TOPIC_NAME_DELIMITER = "_";
+    private static final DateTimeFormatter MEETING_CREATE_AT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
     @Column(name = "fcm_topic")
     private String value;
+
+    public FcmTopic(Meeting meeting) {
+        this(build(meeting));
+    }
+
+    public FcmTopic(String rawValue) {
+        this.value = rawValue.replace(":", "-");
+    }
+
+    private static String build(Meeting meeting) {
+        return meeting.getId().toString()
+                + TOPIC_NAME_DELIMITER
+                + meeting.getCreatedAt().format(MEETING_CREATE_AT_FORMAT);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FcmTopic fcmTopic = (FcmTopic) o;
+        return Objects.equals(getValue(), fcmTopic.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getValue());
+    }
 }

--- a/src/main/java/org/example/odiya/notification/domain/Notification.java
+++ b/src/main/java/org/example/odiya/notification/domain/Notification.java
@@ -1,10 +1,7 @@
 package org.example.odiya.notification.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.example.odiya.common.domain.BaseEntity;
 import org.example.odiya.mate.domain.Mate;
 
@@ -12,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {

--- a/src/main/java/org/example/odiya/notification/domain/Notification.java
+++ b/src/main/java/org/example/odiya/notification/domain/Notification.java
@@ -35,4 +35,16 @@ public class Notification extends BaseEntity {
 
     @Embedded
     private FcmTopic fcmTopic;
+
+    public boolean isStatusDismissed() {
+        return status == NotificationStatus.DISMISSED;
+    }
+
+    public boolean isReminder() {
+        return type == NotificationType.REMINDER;
+    }
+
+    public void updateStatusToDone() {
+        this.status = NotificationStatus.DONE;
+    }
 }

--- a/src/main/java/org/example/odiya/notification/domain/NotificationType.java
+++ b/src/main/java/org/example/odiya/notification/domain/NotificationType.java
@@ -4,6 +4,7 @@ public enum NotificationType {
 
     ENTRY,
     LEAVE,
-    REMINDER
+    REMINDER,
+    HURRYUP,
 
 }

--- a/src/main/java/org/example/odiya/notification/domain/message/DirectMessage.java
+++ b/src/main/java/org/example/odiya/notification/domain/message/DirectMessage.java
@@ -1,0 +1,30 @@
+package org.example.odiya.notification.domain.message;
+
+import com.google.firebase.messaging.Message;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.Notification;
+
+public record DirectMessage(Message message) {
+
+    public static DirectMessage createMessageToOther(Mate sender, Notification notification) {
+        return new DirectMessage(
+                Message.builder()
+                        .putData("type", notification.getType().name())
+                        .putData("name", sender.getMember().getName())
+                        .putData("meetingId", sender.getMeeting().getId().toString())
+                        .setToken(notification.getMate().getMember().getDeviceToken().getValue())
+                        .build()
+        );
+    }
+
+    public static DirectMessage createMessageToSelf(Notification notification) {
+        return new DirectMessage(
+                Message.builder()
+                        .putData("type", notification.getType().name())
+                        .putData("name", notification.getMate().getMember().getName())
+                        .putData("meetingId", notification.getMate().getMeeting().getId().toString())
+                        .setToken(notification.getMate().getMember().getDeviceToken().getValue())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/org/example/odiya/notification/domain/message/GroupMessage.java
+++ b/src/main/java/org/example/odiya/notification/domain/message/GroupMessage.java
@@ -1,0 +1,32 @@
+package org.example.odiya.notification.domain.message;
+
+import com.google.firebase.messaging.Message;
+import org.example.odiya.meeting.domain.Meeting;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.example.odiya.notification.domain.Notification;
+
+public record GroupMessage(Message message) {
+
+    public static GroupMessage createGlobalNotice(Notification notification) {
+        return new GroupMessage(
+                Message.builder()
+                        .putData("type", notification.getType().name())
+                        .putData("name", notification.getMate().getMember().getName())
+                        .putData("meetingId", notification.getMate().getMeeting().getId().toString())
+                        .setToken(notification.getMate().getMember().getDeviceToken().getValue())
+                        .build()
+        );
+    }
+
+    public static GroupMessage createMeetingNotice(Meeting meeting, Notification notification) {
+        FcmTopic fcmTopic = new FcmTopic(meeting);
+        return new GroupMessage(
+                Message.builder()
+                        .putData("type", notification.getType().name())
+                        .putData("name", notification.getMate().getMember().getName())
+                        .putData("meetingId", meeting.getId().toString())
+                        .setTopic(fcmTopic.getValue())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/org/example/odiya/notification/domain/types/EntryNotification.java
+++ b/src/main/java/org/example/odiya/notification/domain/types/EntryNotification.java
@@ -1,0 +1,20 @@
+package org.example.odiya.notification.domain.types;
+
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.example.odiya.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class EntryNotification extends AbstractNotification {
+
+    public EntryNotification(Mate mate, FcmTopic fcmTopic) {
+        super(mate, LocalDateTime.now(), NotificationStatus.DONE, fcmTopic);
+    }
+
+    @Override
+    NotificationType getType() {
+        return NotificationType.ENTRY;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/domain/types/HurryUpNotification.java
+++ b/src/main/java/org/example/odiya/notification/domain/types/HurryUpNotification.java
@@ -1,0 +1,19 @@
+package org.example.odiya.notification.domain.types;
+
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.example.odiya.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class HurryUpNotification extends AbstractNotification {
+
+    public HurryUpNotification(Mate mate) {
+        super(mate, LocalDateTime.now(), NotificationStatus.DONE, null);
+    }
+
+    @Override
+    NotificationType getType() {
+        return NotificationType.HURRYUP;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/domain/types/LeaveNotification.java
+++ b/src/main/java/org/example/odiya/notification/domain/types/LeaveNotification.java
@@ -1,0 +1,19 @@
+package org.example.odiya.notification.domain.types;
+
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.example.odiya.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class LeaveNotification extends AbstractNotification {
+
+    public LeaveNotification(Mate mate) {
+        super(mate, LocalDateTime.now(), NotificationStatus.DONE, null);
+    }
+
+    @Override
+    NotificationType getType() {
+        return NotificationType.LEAVE;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/domain/types/ReminderNotification.java
+++ b/src/main/java/org/example/odiya/notification/domain/types/ReminderNotification.java
@@ -1,0 +1,25 @@
+package org.example.odiya.notification.domain.types;
+
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.meeting.domain.Meeting;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.example.odiya.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class ReminderNotification extends AbstractNotification {
+
+    public ReminderNotification(Meeting meeting, Mate mate, LocalDateTime departureTime, FcmTopic fcmTopic) {
+        super(mate, getDepartureTime(meeting, mate.getEstimatedTime()), NotificationStatus.PENDING, fcmTopic);
+    }
+
+    public static LocalDateTime getDepartureTime(Meeting meeting, long estimatedTime) {
+        return meeting.getMeetingTime().minusMinutes(estimatedTime);
+    }
+
+    @Override
+    NotificationType getType() {
+        return NotificationType.REMINDER;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/domain/types/ReminderNotification.java
+++ b/src/main/java/org/example/odiya/notification/domain/types/ReminderNotification.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 public class ReminderNotification extends AbstractNotification {
 
-    public ReminderNotification(Meeting meeting, Mate mate, LocalDateTime departureTime, FcmTopic fcmTopic) {
+    public ReminderNotification(Meeting meeting, Mate mate, FcmTopic fcmTopic) {
         super(mate, getDepartureTime(meeting, mate.getEstimatedTime()), NotificationStatus.PENDING, fcmTopic);
     }
 

--- a/src/main/java/org/example/odiya/notification/dto/request/HurryUpRequest.java
+++ b/src/main/java/org/example/odiya/notification/dto/request/HurryUpRequest.java
@@ -1,0 +1,19 @@
+package org.example.odiya.notification.dto.request;
+
+import lombok.Getter;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.Notification;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class HurryUpRequest extends ApplicationEvent {
+
+    private final Mate mate;
+    private final Notification notification;
+
+    public HurryUpRequest(Object object, Mate mate, Notification notification) {
+        super(object);
+        this.mate = mate;
+        this.notification = notification;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/dto/request/NoticeRequest.java
+++ b/src/main/java/org/example/odiya/notification/dto/request/NoticeRequest.java
@@ -1,0 +1,16 @@
+package org.example.odiya.notification.dto.request;
+
+import lombok.Getter;
+import org.example.odiya.notification.domain.message.GroupMessage;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class NoticeRequest extends ApplicationEvent {
+
+    private final GroupMessage groupMessage;
+
+    public NoticeRequest(Object object, GroupMessage groupMessage) {
+        super(object);
+        this.groupMessage = groupMessage;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/dto/request/PushRequest.java
+++ b/src/main/java/org/example/odiya/notification/dto/request/PushRequest.java
@@ -1,0 +1,19 @@
+package org.example.odiya.notification.dto.request;
+
+import lombok.Getter;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.message.GroupMessage;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class PushRequest extends ApplicationEvent {
+
+    private final Notification notification;
+    private final GroupMessage groupMessage;
+
+    public PushRequest(Object object, Notification notification) {
+        super(object);
+        this.notification = notification;
+        this.groupMessage = GroupMessage.createGlobalNotice(notification);
+    }
+}

--- a/src/main/java/org/example/odiya/notification/dto/request/SubscribeRequest.java
+++ b/src/main/java/org/example/odiya/notification/dto/request/SubscribeRequest.java
@@ -1,0 +1,20 @@
+package org.example.odiya.notification.dto.request;
+
+import lombok.Getter;
+import org.example.odiya.member.domain.DeviceToken;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class SubscribeRequest extends ApplicationEvent {
+
+    private final DeviceToken deviceToken;
+    private final FcmTopic fcmTopic;
+
+
+    public SubscribeRequest(Object object, DeviceToken deviceToken, FcmTopic fcmTopic) {
+        super(object);
+        this.deviceToken = deviceToken;
+        this.fcmTopic = fcmTopic;
+    }
+}

--- a/src/main/java/org/example/odiya/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/odiya/notification/repository/NotificationRepository.java
@@ -1,7 +1,19 @@
 package org.example.odiya.notification.repository;
 
 import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT noti" +
+            " FROM Notification noti" +
+            " JOIN FETCH Mate mate on noti.mate.id = mate.id and mate.meeting.id = :meetingId" +
+            " JOIN FETCH Member member on mate.member.id = member.id" +
+            " WHERE noti.type = :type")
+    List<Notification> findAllMeetingIdAndType(@Param("meetingId") Long meetingId, @Param("type") NotificationType type);
 }

--- a/src/main/java/org/example/odiya/notification/service/NotificationQueryService.java
+++ b/src/main/java/org/example/odiya/notification/service/NotificationQueryService.java
@@ -1,0 +1,25 @@
+package org.example.odiya.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.common.exception.NotFoundException;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.example.odiya.common.exception.type.ErrorType.NOTIFICATION_NOT_FOUND_ERROR;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryService {
+
+    private final NotificationRepository notificationRepository;
+
+    public Notification findById(Long notificationId) {
+        return notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotFoundException(NOTIFICATION_NOT_FOUND_ERROR));
+    }
+}

--- a/src/main/java/org/example/odiya/notification/service/NotificationService.java
+++ b/src/main/java/org/example/odiya/notification/service/NotificationService.java
@@ -7,6 +7,7 @@ import org.example.odiya.meeting.domain.Meeting;
 import org.example.odiya.member.domain.DeviceToken;
 import org.example.odiya.notification.domain.FcmTopic;
 import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.NotificationType;
 import org.example.odiya.notification.domain.types.HurryUpNotification;
 import org.example.odiya.notification.service.event.HurryUpEvent;
 import org.example.odiya.notification.service.event.PushEvent;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -74,5 +76,16 @@ public class NotificationService {
     public void unsubscribeTopic(Meeting meeting, DeviceToken deviceToken) {
         FcmTopic fcmTopic = new FcmTopic(meeting);
         fcmPublisher.publish(new SubscribeEvent(this, deviceToken, fcmTopic));
+    }
+
+    public void unsubscribeTopics(List<Meeting> meetingList) {
+        for (Meeting meeting : meetingList) {
+            notificationRepository
+                    .findAllMeetingIdAndType(meeting.getId(), NotificationType.REMINDER)
+                    .forEach(notification -> unsubscribeTopic(
+                            meeting,
+                            notification.getMate().getMember().getDeviceToken()
+                    ));
+        }
     }
 }

--- a/src/main/java/org/example/odiya/notification/service/NotificationService.java
+++ b/src/main/java/org/example/odiya/notification/service/NotificationService.java
@@ -14,7 +14,6 @@ import org.example.odiya.notification.service.event.PushEvent;
 import org.example.odiya.notification.service.event.SubscribeEvent;
 import org.example.odiya.notification.repository.NotificationRepository;
 import org.example.odiya.notification.service.fcm.FcmPublisher;
-import org.example.odiya.notification.service.fcm.FcmPushSender;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +30,6 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final FcmPublisher fcmPublisher;
     private final TaskScheduler taskScheduler;
-    private final FcmPushSender fcmPushSender;
 
     @Transactional
     public void saveAndScheduleNotification(Notification notification) {
@@ -64,9 +62,9 @@ public class NotificationService {
     }
 
     @Transactional
-    public void sendHurryUpNotification(Mate mate, HurryUpNotification hurryUpNotification) {
+    public void sendHurryUpNotification(Mate sender, HurryUpNotification hurryUpNotification) {
         Notification savedNotification = saveNotification(hurryUpNotification.toNotification());
-        fcmPublisher.publishWithTransaction(new HurryUpEvent(this, mate, savedNotification));
+        fcmPublisher.publishWithTransaction(new HurryUpEvent(this, sender, savedNotification));
     }
 
     public void subscribeTopic(DeviceToken deviceToken, FcmTopic fcmTopic) {

--- a/src/main/java/org/example/odiya/notification/service/NotificationService.java
+++ b/src/main/java/org/example/odiya/notification/service/NotificationService.java
@@ -1,0 +1,54 @@
+package org.example.odiya.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.dto.request.PushRequest;
+import org.example.odiya.notification.repository.NotificationRepository;
+import org.example.odiya.notification.service.fcm.FcmPublisher;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final FcmPublisher fcmPublisher;
+    private final TaskScheduler taskScheduler;
+
+    @Transactional
+    public void saveAndScheduleNotification(Notification notification) {
+        Notification savedNotification = saveNotification(notification);
+        scheduleNotification(savedNotification);
+    }
+
+    @Transactional
+    public Notification saveNotification(Notification notification) {
+        return notificationRepository.save(notification);
+    }
+
+    private void scheduleNotification(Notification notification) {
+        LocalDateTime sendAt = notification.getSendAt();
+        PushRequest pushRequest = new PushRequest(this, notification);
+        taskScheduler.schedule(
+                () -> fcmPublisher.publishWithTransaction(pushRequest),
+                sendAt.atZone(ZoneId.systemDefault()).toInstant()
+        );
+        log.info("알림 스케줄링 - type: {}, 예약시간: {}", notification.getType(), sendAt);
+    }
+
+    public void updateStatusToDone(Notification notification) {
+        if (notification.isReminder()) {
+            notification.updateStatusToDone();
+            log.info("알림 상태 업데이트 - id: {}, type: {}",
+                    notification.getId(),
+                    notification.getType());
+        }
+    }
+}

--- a/src/main/java/org/example/odiya/notification/service/NotificationService.java
+++ b/src/main/java/org/example/odiya/notification/service/NotificationService.java
@@ -2,10 +2,14 @@ package org.example.odiya.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.mate.domain.Mate;
 import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.types.HurryUpNotification;
+import org.example.odiya.notification.dto.request.HurryUpRequest;
 import org.example.odiya.notification.dto.request.PushRequest;
 import org.example.odiya.notification.repository.NotificationRepository;
 import org.example.odiya.notification.service.fcm.FcmPublisher;
+import org.example.odiya.notification.service.fcm.FcmPushSender;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +25,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final FcmPublisher fcmPublisher;
     private final TaskScheduler taskScheduler;
+    private final FcmPushSender fcmPushSender;
 
     @Transactional
     public void saveAndScheduleNotification(Notification notification) {
@@ -50,5 +55,13 @@ public class NotificationService {
                     notification.getId(),
                     notification.getType());
         }
+    }
+
+    @Transactional
+    public void sendHurryUpNotification(Mate mate, Notification notification) {
+        HurryUpNotification hurryUpNotification = new HurryUpNotification(mate);
+        Notification savedNotification = saveNotification(hurryUpNotification.toNotification());
+        HurryUpRequest hurryUpRequest = new HurryUpRequest(this, mate, savedNotification);
+        fcmPublisher.publishWithTransaction(hurryUpRequest);
     }
 }

--- a/src/main/java/org/example/odiya/notification/service/event/HurryUpEvent.java
+++ b/src/main/java/org/example/odiya/notification/service/event/HurryUpEvent.java
@@ -1,4 +1,4 @@
-package org.example.odiya.notification.dto.request;
+package org.example.odiya.notification.service.event;
 
 import lombok.Getter;
 import org.example.odiya.mate.domain.Mate;
@@ -6,12 +6,12 @@ import org.example.odiya.notification.domain.Notification;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class HurryUpRequest extends ApplicationEvent {
+public class HurryUpEvent extends ApplicationEvent {
 
     private final Mate mate;
     private final Notification notification;
 
-    public HurryUpRequest(Object object, Mate mate, Notification notification) {
+    public HurryUpEvent(Object object, Mate mate, Notification notification) {
         super(object);
         this.mate = mate;
         this.notification = notification;

--- a/src/main/java/org/example/odiya/notification/service/event/NoticeEvent.java
+++ b/src/main/java/org/example/odiya/notification/service/event/NoticeEvent.java
@@ -1,15 +1,15 @@
-package org.example.odiya.notification.dto.request;
+package org.example.odiya.notification.service.event;
 
 import lombok.Getter;
 import org.example.odiya.notification.domain.message.GroupMessage;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class NoticeRequest extends ApplicationEvent {
+public class NoticeEvent extends ApplicationEvent {
 
     private final GroupMessage groupMessage;
 
-    public NoticeRequest(Object object, GroupMessage groupMessage) {
+    public NoticeEvent(Object object, GroupMessage groupMessage) {
         super(object);
         this.groupMessage = groupMessage;
     }

--- a/src/main/java/org/example/odiya/notification/service/event/PushEvent.java
+++ b/src/main/java/org/example/odiya/notification/service/event/PushEvent.java
@@ -1,4 +1,4 @@
-package org.example.odiya.notification.dto.request;
+package org.example.odiya.notification.service.event;
 
 import lombok.Getter;
 import org.example.odiya.notification.domain.Notification;
@@ -6,12 +6,12 @@ import org.example.odiya.notification.domain.message.GroupMessage;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class PushRequest extends ApplicationEvent {
+public class PushEvent extends ApplicationEvent {
 
     private final Notification notification;
     private final GroupMessage groupMessage;
 
-    public PushRequest(Object object, Notification notification) {
+    public PushEvent(Object object, Notification notification) {
         super(object);
         this.notification = notification;
         this.groupMessage = GroupMessage.createGlobalNotice(notification);

--- a/src/main/java/org/example/odiya/notification/service/event/SubscribeEvent.java
+++ b/src/main/java/org/example/odiya/notification/service/event/SubscribeEvent.java
@@ -1,4 +1,4 @@
-package org.example.odiya.notification.dto.request;
+package org.example.odiya.notification.service.event;
 
 import lombok.Getter;
 import org.example.odiya.member.domain.DeviceToken;
@@ -6,13 +6,13 @@ import org.example.odiya.notification.domain.FcmTopic;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class SubscribeRequest extends ApplicationEvent {
+public class SubscribeEvent extends ApplicationEvent {
 
     private final DeviceToken deviceToken;
     private final FcmTopic fcmTopic;
 
 
-    public SubscribeRequest(Object object, DeviceToken deviceToken, FcmTopic fcmTopic) {
+    public SubscribeEvent(Object object, DeviceToken deviceToken, FcmTopic fcmTopic) {
         super(object);
         this.deviceToken = deviceToken;
         this.fcmTopic = fcmTopic;

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmEventListener.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmEventListener.java
@@ -1,0 +1,71 @@
+package org.example.odiya.notification.service.fcm;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.message.DirectMessage;
+import org.example.odiya.notification.domain.message.GroupMessage;
+import org.example.odiya.notification.dto.request.HurryUpRequest;
+import org.example.odiya.notification.dto.request.NoticeRequest;
+import org.example.odiya.notification.dto.request.PushRequest;
+import org.example.odiya.notification.dto.request.SubscribeRequest;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmEventListener {
+
+    private final FcmPushSender fcmPushSender;
+    private final FcmSubscriber fcmSubscriber;
+
+    @Async("fcmExecutor")
+    @EventListener
+    public void handleSubscribe(SubscribeRequest request) {
+        fcmSubscriber.subscribeTopic(request.getFcmTopic(), request.getDeviceToken());
+        log.info("토픽 구독 완료 - topic: {}, token: {}",
+                request.getFcmTopic().getValue(),
+                request.getDeviceToken().getValue());
+    }
+
+    @Async("fcmExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePush(PushRequest request) {
+        GroupMessage groupMessage = request.getGroupMessage();
+        Notification notification = request.getNotification();
+
+        fcmPushSender.sendGroupMessage(groupMessage, notification);
+        log.info("푸시 알림 전송 - id: {}, type: {}",
+                notification.getId(),
+                notification.getType());
+    }
+
+    @Async("fcmExecutor")
+    @EventListener
+    public void handleNotice(NoticeRequest request) {
+        GroupMessage groupMessage = request.getGroupMessage();
+        fcmPushSender.sendNoticeMessage(groupMessage);
+        log.info("공지 알림 전송 시간: {}", Instant.now().atZone(ZoneId.systemDefault()));
+    }
+
+    @Async("fcmExecutor")
+    @EventListener
+    public void handleHurryUp(HurryUpRequest request) {
+        Mate mate = request.getMate();
+        Notification notification = request.getNotification();
+
+        DirectMessage directMessage = DirectMessage.createMessageToOther(mate, notification);
+        fcmPushSender.sendDirectMessage(directMessage);
+        log.info("재촉하기 알림 전송 - id: {}, 전송시간: {}",
+                notification.getId(),
+                notification.getSendAt());
+    }
+}

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmPublisher.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmPublisher.java
@@ -1,0 +1,23 @@
+package org.example.odiya.notification.service.fcm;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FcmPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publish(ApplicationEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+
+    @Transactional
+    public void publishWithTransaction(ApplicationEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmPushSender.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmPushSender.java
@@ -12,8 +12,9 @@ import org.example.odiya.notification.domain.message.GroupMessage;
 import org.example.odiya.notification.service.NotificationQueryService;
 import org.example.odiya.notification.service.NotificationService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
-import static org.example.odiya.common.exception.type.ErrorType.FIREBASE_SEND_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.*;
 
 @Slf4j
 @Component
@@ -27,7 +28,7 @@ public class FcmPushSender {
     public void sendGroupMessage(GroupMessage groupMessage, Notification notification) {
         Notification savedNotification = notificationQueryService.findById(notification.getId());
         if (savedNotification.isStatusDismissed()) {
-            log.info("DISMISSED 상태 알림 전송 스킵 - id: {}", notification.getId());
+            log.info("DISMISSED 상태 알림 전송 스킵 - id: {}", savedNotification.getId());
             return;
         }
         sendMessage(groupMessage.message());
@@ -46,8 +47,11 @@ public class FcmPushSender {
         try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
-            log.error("메시지 전송 실패 - error: {}", e.getMessage());
+            log.error("메시지 전송 FirebaseMessagingException - error: {}", e.getMessage());
             throw new InternalServerException(FIREBASE_SEND_ERROR);
+        } catch (Exception e) {
+            log.error("메시지 전송 Exception - error: {}", e.getMessage());
+            throw new InternalServerException(INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmPushSender.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmPushSender.java
@@ -1,0 +1,53 @@
+package org.example.odiya.notification.service.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.common.exception.InternalServerException;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.message.DirectMessage;
+import org.example.odiya.notification.domain.message.GroupMessage;
+import org.example.odiya.notification.service.NotificationQueryService;
+import org.example.odiya.notification.service.NotificationService;
+import org.springframework.stereotype.Component;
+
+import static org.example.odiya.common.exception.type.ErrorType.FIREBASE_SEND_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmPushSender {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final NotificationService notificationService;
+    private final NotificationQueryService notificationQueryService;
+
+    public void sendGroupMessage(GroupMessage groupMessage, Notification notification) {
+        Notification savedNotification = notificationQueryService.findById(notification.getId());
+        if (savedNotification.isStatusDismissed()) {
+            log.info("DISMISSED 상태 알림 전송 스킵 - id: {}", notification.getId());
+            return;
+        }
+        sendMessage(groupMessage.message());
+        notificationService.updateStatusToDone(savedNotification);
+    }
+
+    public void sendNoticeMessage(GroupMessage groupMessage) {
+        sendMessage(groupMessage.message());
+    }
+
+    public void sendDirectMessage(DirectMessage directMessage) {
+        sendMessage(directMessage.message());
+    }
+
+    private void sendMessage(Message message) {
+        try {
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            log.error("메시지 전송 실패 - error: {}", e.getMessage());
+            throw new InternalServerException(FIREBASE_SEND_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmSubscriber.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmSubscriber.java
@@ -1,0 +1,47 @@
+package org.example.odiya.notification.service.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.common.exception.InternalServerException;
+import org.example.odiya.member.domain.DeviceToken;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static org.example.odiya.common.exception.type.ErrorType.FIREBASE_SUBSCRIBE_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.FIREBASE_UNSUBSCRIBE_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmSubscriber {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void subscribeTopic(FcmTopic fcmTopic, DeviceToken deviceToken) {
+        try {
+            firebaseMessaging.subscribeToTopic(
+                    List.of(deviceToken.getValue()),
+                    fcmTopic.getValue()
+            );
+        } catch (FirebaseMessagingException e) {
+            log.error("토픽 구독 실패 - topic: {}, error: {}", fcmTopic.getValue(), e.getMessage());
+            throw new InternalServerException(FIREBASE_SUBSCRIBE_ERROR, e.getMessage());
+        }
+    }
+
+    public void unsubscribeTopic(FcmTopic topic, DeviceToken deviceToken) {
+        try {
+            firebaseMessaging.unsubscribeFromTopic(
+                    List.of(deviceToken.getValue()),
+                    topic.getValue()
+            );
+        } catch (FirebaseMessagingException e) {
+            log.error("토픽 구독 해제 실패 - topic: {}, error: {}", topic.getValue(), e.getMessage());
+            throw new InternalServerException(FIREBASE_UNSUBSCRIBE_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/example/odiya/common/BaseTest/BaseServiceTest.java
+++ b/src/test/java/org/example/odiya/common/BaseTest/BaseServiceTest.java
@@ -1,14 +1,19 @@
 package org.example.odiya.common.BaseTest;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import org.example.odiya.common.Fixture.DtoGenerator;
 import org.example.odiya.common.Fixture.FixtureGenerator;
 import org.example.odiya.common.config.FixtureGeneratorConfig;
 import org.example.odiya.common.config.TestAuthConfig;
 import org.example.odiya.common.config.TestRouteConfig;
+import org.example.odiya.notification.config.FcmConfig;
+import org.example.odiya.notification.service.fcm.FcmEventListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
 @Import({TestRouteConfig.class, FixtureGeneratorConfig.class, TestAuthConfig.class})
@@ -19,6 +24,18 @@ public abstract class BaseServiceTest {
 
     @Autowired
     protected FixtureGenerator fixtureGenerator;
+
+    @MockBean
+    protected FcmEventListener fcmEventListener;
+
+    @MockBean
+    private FcmConfig fcmConfig;
+
+    @MockBean
+    protected FirebaseMessaging firebaseMessaging;
+
+    @Autowired
+    protected ApplicationEvents applicationEvents;
 
     protected DtoGenerator dtoGenerator = new DtoGenerator();
 }

--- a/src/test/java/org/example/odiya/common/BaseTest/BaseServiceTest.java
+++ b/src/test/java/org/example/odiya/common/BaseTest/BaseServiceTest.java
@@ -5,8 +5,8 @@ import org.example.odiya.common.Fixture.DtoGenerator;
 import org.example.odiya.common.Fixture.FixtureGenerator;
 import org.example.odiya.common.config.FixtureGeneratorConfig;
 import org.example.odiya.common.config.TestAuthConfig;
+import org.example.odiya.common.config.TestFcmConfig;
 import org.example.odiya.common.config.TestRouteConfig;
-import org.example.odiya.notification.config.FcmConfig;
 import org.example.odiya.notification.service.fcm.FcmEventListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
-@Import({TestRouteConfig.class, FixtureGeneratorConfig.class, TestAuthConfig.class})
+@Import({TestRouteConfig.class, FixtureGeneratorConfig.class, TestAuthConfig.class, TestFcmConfig.class})
 @ActiveProfiles("test")
 @RecordApplicationEvents
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -27,12 +27,6 @@ public abstract class BaseServiceTest {
 
     @MockBean
     protected FcmEventListener fcmEventListener;
-
-    @MockBean
-    private FcmConfig fcmConfig;
-
-    @MockBean
-    protected FirebaseMessaging firebaseMessaging;
 
     @Autowired
     protected ApplicationEvents applicationEvents;

--- a/src/test/java/org/example/odiya/common/config/FixtureGeneratorConfig.java
+++ b/src/test/java/org/example/odiya/common/config/FixtureGeneratorConfig.java
@@ -5,6 +5,7 @@ import org.example.odiya.eta.repository.EtaRepository;
 import org.example.odiya.mate.repository.MateRepository;
 import org.example.odiya.meeting.repository.MeetingRepository;
 import org.example.odiya.member.repository.MemberRepository;
+import org.example.odiya.notification.repository.NotificationRepository;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -18,13 +19,15 @@ public class FixtureGeneratorConfig {
             MemberRepository memberRepository,
             MeetingRepository meetingRepository,
             MateRepository mateRepository,
-            EtaRepository etaRepository
+            EtaRepository etaRepository,
+            NotificationRepository notificationRepository
     ) {
         return new FixtureGenerator(
                 memberRepository,
                 meetingRepository,
                 mateRepository,
-                etaRepository
+                etaRepository,
+                notificationRepository
         );
     }
 }

--- a/src/test/java/org/example/odiya/common/config/TestFcmConfig.java
+++ b/src/test/java/org/example/odiya/common/config/TestFcmConfig.java
@@ -1,0 +1,18 @@
+package org.example.odiya.common.config;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import static org.mockito.Mockito.mock;
+
+@Configuration
+@Profile("test")
+public class TestFcmConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return mock(FirebaseMessaging.class);
+    }
+}

--- a/src/test/java/org/example/odiya/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/org/example/odiya/meeting/service/MeetingServiceTest.java
@@ -197,11 +197,10 @@ class MeetingServiceTest extends BaseServiceTest {
     }
 
     @Test
-    @DisplayName("모임 시간 1시간 전이 아닌 경우 예외를 발생시킨다")
+    @DisplayName("현재시간이 약속 시간 1시간 전보다 이전일경우 예외를 발생시킨다")
     void throwExceptionWhenNotOneHourBeforeMeeting() {
         // Given
         Meeting futureMeeting = fixtureGenerator.generateMeeting(LocalDateTime.now().plusDays(1));
-
         fixtureGenerator.generateMate(futureMeeting, member);
 
         // When & Then

--- a/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
+++ b/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
@@ -45,8 +45,8 @@ class NotificationServiceTest extends BaseServiceTest {
         notificationRepository.deleteAll();
     }
 
-    @DisplayName("알림을 저장하고 스케줄링한다")
     @Test
+    @DisplayName("알림을 저장하고 스케줄링한다")
     void saveAndScheduleNotification() {
         // given
         Mate mate = fixtureGenerator.generateMate();
@@ -67,8 +67,8 @@ class NotificationServiceTest extends BaseServiceTest {
         assertThat(notificationRepository.findAll()).hasSize(1);
     }
 
-    @DisplayName("REMINDER 타입의 알림 상태를 DONE으로 변경한다")
     @Test
+    @DisplayName("REMINDER 타입의 알림 상태를 DONE으로 변경한다")
     void updateReminderStatusToDone() {
         // given
         Mate mate = fixtureGenerator.generateMate();
@@ -85,8 +85,8 @@ class NotificationServiceTest extends BaseServiceTest {
         assertThat(notification.getStatus()).isEqualTo(NotificationStatus.DONE);
     }
 
-    @DisplayName("REMINDER가 아닌 알림은 상태가 변경되지 않는다")
     @Test
+    @DisplayName("REMINDER가 아닌 알림은 상태가 변경되지 않는다")
     void notUpdateNonReminderStatus() {
         // given
         Mate mate = fixtureGenerator.generateMate();
@@ -103,8 +103,8 @@ class NotificationServiceTest extends BaseServiceTest {
         assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
     }
 
-    @DisplayName("재촉하기 알림을 저장하고 이벤트를 발행한다")
     @Test
+    @DisplayName("재촉하기 알림을 저장하고 이벤트를 발행한다")
     void sendHurryUpNotification() {
         // given
         Meeting meeting = fixtureGenerator.generateMeeting();
@@ -120,8 +120,8 @@ class NotificationServiceTest extends BaseServiceTest {
         assertThat(notificationRepository.findAll()).hasSize(1);
     }
 
-    @DisplayName("토픽 구독 이벤트를 발행한다")
     @Test
+    @DisplayName("토픽 구독 이벤트를 발행한다")
     void subscribeTopic() {
         // given
         Meeting meeting = fixtureGenerator.generateMeeting();
@@ -135,8 +135,8 @@ class NotificationServiceTest extends BaseServiceTest {
         verify(fcmPublisher).publishWithTransaction(any(SubscribeEvent.class));
     }
 
-    @DisplayName("토픽 구독 해제 이벤트를 발행한다")
     @Test
+    @DisplayName("토픽 구독 해제 이벤트를 발행한다")
     void unsubscribeTopic() {
         // given
         Meeting meeting = fixtureGenerator.generateMeeting();

--- a/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
+++ b/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
@@ -1,0 +1,151 @@
+package org.example.odiya.notification.service;
+
+import org.example.odiya.common.BaseTest.BaseServiceTest;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.meeting.domain.Meeting;
+import org.example.odiya.member.domain.DeviceToken;
+import org.example.odiya.notification.domain.FcmTopic;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.example.odiya.notification.domain.NotificationType;
+import org.example.odiya.notification.domain.types.HurryUpNotification;
+import org.example.odiya.notification.repository.NotificationRepository;
+import org.example.odiya.notification.service.event.HurryUpEvent;
+import org.example.odiya.notification.service.event.SubscribeEvent;
+import org.example.odiya.notification.service.fcm.FcmPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
+class NotificationServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @MockBean
+    private TaskScheduler taskScheduler;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private FcmPublisher fcmPublisher;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+    }
+
+    @DisplayName("알림을 저장하고 스케줄링한다")
+    @Test
+    void saveAndScheduleNotification() {
+        // given
+        Mate mate = fixtureGenerator.generateMate();
+        Notification notification = fixtureGenerator.generateNotification(
+                mate,
+                NotificationType.REMINDER,
+                NotificationStatus.PENDING
+        );
+
+        // when
+        notificationService.saveAndScheduleNotification(notification);
+
+        // then
+        verify(taskScheduler).schedule(
+                any(Runnable.class),
+                any(Instant.class)
+        );
+        assertThat(notificationRepository.findAll()).hasSize(1);
+    }
+
+    @DisplayName("REMINDER 타입의 알림 상태를 DONE으로 변경한다")
+    @Test
+    void updateReminderStatusToDone() {
+        // given
+        Mate mate = fixtureGenerator.generateMate();
+        Notification notification = fixtureGenerator.generateNotification(
+                mate,
+                NotificationType.REMINDER,
+                NotificationStatus.PENDING
+        );
+
+        // when
+        notificationService.updateStatusToDone(notification);
+
+        // then
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.DONE);
+    }
+
+    @DisplayName("REMINDER가 아닌 알림은 상태가 변경되지 않는다")
+    @Test
+    void notUpdateNonReminderStatus() {
+        // given
+        Mate mate = fixtureGenerator.generateMate();
+        Notification notification = fixtureGenerator.generateNotification(
+                mate,
+                NotificationType.ENTRY,
+                NotificationStatus.PENDING
+        );
+
+        // when
+        notificationService.updateStatusToDone(notification);
+
+        // then
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
+    }
+
+    @DisplayName("재촉하기 알림을 저장하고 이벤트를 발행한다")
+    @Test
+    void sendHurryUpNotification() {
+        // given
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        Mate sender = fixtureGenerator.generateMate(meeting);
+        Mate receiver = fixtureGenerator.generateMate(meeting);
+        HurryUpNotification hurryUpNotification = new HurryUpNotification(receiver);
+
+        // when
+        notificationService.sendHurryUpNotification(sender, hurryUpNotification);
+
+        // then
+        verify(fcmPublisher).publishWithTransaction(any(HurryUpEvent.class));
+        assertThat(notificationRepository.findAll()).hasSize(1);
+    }
+
+    @DisplayName("토픽 구독 이벤트를 발행한다")
+    @Test
+    void subscribeTopic() {
+        // given
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        DeviceToken deviceToken = new DeviceToken("test-token");
+        FcmTopic fcmTopic = new FcmTopic(meeting);
+
+        // when
+        notificationService.subscribeTopic(deviceToken, fcmTopic);
+
+        // then
+        verify(fcmPublisher).publishWithTransaction(any(SubscribeEvent.class));
+    }
+
+    @DisplayName("토픽 구독 해제 이벤트를 발행한다")
+    @Test
+    void unsubscribeTopic() {
+        // given
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        DeviceToken deviceToken = new DeviceToken("test-token");
+
+        // when
+        notificationService.unsubscribeTopic(meeting, deviceToken);
+
+        // then
+        verify(fcmPublisher).publish(any(SubscribeEvent.class));
+    }
+}

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmEventListenerTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmEventListenerTest.java
@@ -1,0 +1,92 @@
+package org.example.odiya.notification.service.fcm;
+
+import org.example.odiya.common.BaseTest.BaseServiceTest;
+import org.example.odiya.notification.service.event.HurryUpEvent;
+import org.example.odiya.notification.service.event.NoticeEvent;
+import org.example.odiya.notification.service.event.PushEvent;
+import org.example.odiya.notification.service.event.SubscribeEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
+class FcmEventListenerTest extends BaseServiceTest {
+
+    @Autowired
+    private FcmPublisher fcmPublisher;
+
+    @DisplayName("SubscribeEvent 이벤트가 발행되면 구독 로직이 실행된다")
+    @Test
+    void subscribeTopic() {
+        // given
+        SubscribeEvent subscribeEvent = mock(SubscribeEvent.class);
+
+        // when
+        fcmPublisher.publish(subscribeEvent);
+
+        // then
+        verify(fcmEventListener, times(1)).handleSubscribe(eq(subscribeEvent));
+    }
+
+    @DisplayName("UnsubscribeEvent 발생 시, 주제 구독 해제 로직을 실행한다")
+    @Test
+    void handleUnSubscribe() {
+        // given
+        SubscribeEvent unSubscribeEvent = mock(SubscribeEvent.class);
+
+        // when
+        fcmPublisher.publish(unSubscribeEvent);
+
+        // then
+        verify(fcmEventListener, times(1)).handleUnSubscribe(eq(unSubscribeEvent));
+    }
+
+    @Test
+    @DisplayName("푸시 알림 이벤트가 발행되고 트랜잭션이 커밋되면 알림 발송 로직이 실행된다")
+    void handlePushEventAfterCommit() {
+        // given
+        PushEvent pushEvent = mock(PushEvent.class);
+
+        // when
+        fcmPublisher.publishWithTransaction(pushEvent);
+
+        // then
+        verify(fcmEventListener, times(1)).handlePush(eq(pushEvent));
+        verify(fcmEventListener).handlePush(pushEvent);
+    }
+
+    @DisplayName("NoticeEvent 발생 시, 공지 알림 발송 로직을 실행한다")
+    @Test
+    void sendNoticeMessage() {
+        // given
+        NoticeEvent noticeEvent = mock(NoticeEvent.class);
+
+        // when
+        fcmPublisher.publish(noticeEvent);
+
+        // then
+        verify(fcmEventListener, times(1)).handleNotice(eq(noticeEvent));
+    }
+
+    @DisplayName("트랜잭션이 열리지 않으면, 푸시 알림 발송 로직이 실행되지 않는다")
+    @Test
+    void notEventTriggerWhenTransactionNotOpen() {
+        PushEvent pushEvent = mock(PushEvent.class);
+
+        fcmPublisher.publish(pushEvent);
+
+        verifyNoInteractions(fcmEventListener);
+    }
+
+    @DisplayName("NudgeEvent 발생 시, 넛지 알림 발송 로직을 실행한다")
+    @Test
+    void sendHurryUpMessage() {
+        HurryUpEvent nudgeEvent = mock(HurryUpEvent.class);
+
+        fcmPublisher.publish(nudgeEvent);
+
+        verify(fcmEventListener, times(1)).handleHurryUp(eq(nudgeEvent));
+    }
+}

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmEventListenerTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmEventListenerTest.java
@@ -17,8 +17,8 @@ class FcmEventListenerTest extends BaseServiceTest {
     @Autowired
     private FcmPublisher fcmPublisher;
 
-    @DisplayName("SubscribeEvent 이벤트가 발행되면 구독 로직이 실행된다")
     @Test
+    @DisplayName("SubscribeEvent 이벤트가 발행되면 구독 로직이 실행된다")
     void subscribeTopic() {
         // given
         SubscribeEvent subscribeEvent = mock(SubscribeEvent.class);
@@ -30,8 +30,8 @@ class FcmEventListenerTest extends BaseServiceTest {
         verify(fcmEventListener, times(1)).handleSubscribe(eq(subscribeEvent));
     }
 
-    @DisplayName("UnsubscribeEvent 발생 시, 주제 구독 해제 로직을 실행한다")
     @Test
+    @DisplayName("UnsubscribeEvent 발생 시, 주제 구독 해제 로직을 실행한다")
     void handleUnSubscribe() {
         // given
         SubscribeEvent unSubscribeEvent = mock(SubscribeEvent.class);
@@ -57,8 +57,8 @@ class FcmEventListenerTest extends BaseServiceTest {
         verify(fcmEventListener).handlePush(pushEvent);
     }
 
-    @DisplayName("NoticeEvent 발생 시, 공지 알림 발송 로직을 실행한다")
     @Test
+    @DisplayName("NoticeEvent 발생 시, 공지 알림 발송 로직을 실행한다")
     void sendNoticeMessage() {
         // given
         NoticeEvent noticeEvent = mock(NoticeEvent.class);
@@ -70,8 +70,8 @@ class FcmEventListenerTest extends BaseServiceTest {
         verify(fcmEventListener, times(1)).handleNotice(eq(noticeEvent));
     }
 
-    @DisplayName("트랜잭션이 열리지 않으면, 푸시 알림 발송 로직이 실행되지 않는다")
     @Test
+    @DisplayName("트랜잭션이 열리지 않으면, 푸시 알림 발송 로직이 실행되지 않는다")
     void notEventTriggerWhenTransactionNotOpen() {
         PushEvent pushEvent = mock(PushEvent.class);
 
@@ -80,8 +80,8 @@ class FcmEventListenerTest extends BaseServiceTest {
         verifyNoInteractions(fcmEventListener);
     }
 
-    @DisplayName("NudgeEvent 발생 시, 넛지 알림 발송 로직을 실행한다")
     @Test
+    @DisplayName("NudgeEvent 발생 시, 넛지 알림 발송 로직을 실행한다")
     void sendHurryUpMessage() {
         HurryUpEvent nudgeEvent = mock(HurryUpEvent.class);
 

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -1,0 +1,119 @@
+package org.example.odiya.notification.service.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.example.odiya.common.BaseTest.BaseServiceTest;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.example.odiya.notification.domain.NotificationType;
+import org.example.odiya.notification.domain.message.DirectMessage;
+import org.example.odiya.notification.domain.message.GroupMessage;
+import org.example.odiya.notification.repository.NotificationRepository;
+import org.example.odiya.notification.service.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+class FcmPushSenderTest extends BaseServiceTest {
+
+    @Autowired
+    private FcmPushSender fcmPushSender;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+    }
+
+    @DisplayName("그룹 메시지를 전송하고 알림 상태를 DONE으로 변경한다")
+    @Test
+    void sendGroupMessageSuccess() throws FirebaseMessagingException {
+        // given
+        Mate mate = fixtureGenerator.generateMate();
+        Notification pendingNotification = fixtureGenerator.generateNotification(
+                mate,
+                NotificationType.REMINDER,
+                NotificationStatus.PENDING
+        );
+        GroupMessage groupMessage = GroupMessage.createGlobalNotice(pendingNotification);
+        // firebaseMessaging mock 설정 추가
+        when(firebaseMessaging.send(any(Message.class)))
+                .thenReturn("message_id");  // 성공 시 반환값 설정
+
+        // when
+        fcmPushSender.sendGroupMessage(groupMessage, pendingNotification);
+
+        // then
+        assertAll(
+                () -> verify(firebaseMessaging).send(any(Message.class)),
+                () -> verify(notificationService).updateStatusToDone(any(Notification.class))
+        );
+    }
+
+    @DisplayName("DISMISSED 상태의 알림은 메시지를 전송하지 않는다")
+    @Test
+    void skipDismissedNotification() {
+        // given
+        Mate mate = fixtureGenerator.generateMate();
+        Notification notification = fixtureGenerator.generateNotification(
+                mate,
+                NotificationType.REMINDER,
+                NotificationStatus.DISMISSED
+        );
+        GroupMessage groupMessage = GroupMessage.createGlobalNotice(notification);
+
+        // when
+        fcmPushSender.sendGroupMessage(groupMessage, notification);
+
+        // then
+        assertAll(
+                () -> verifyNoInteractions(firebaseMessaging),
+                () -> verifyNoInteractions(notificationService)
+        );
+    }
+
+    @DisplayName("다이렉트 메시지를 전송한다")
+    @Test
+    void sendDirectMessage() throws FirebaseMessagingException {
+        // given
+        Message message = mock(Message.class);
+        DirectMessage directMessage = new DirectMessage(message);
+
+        // when
+        fcmPushSender.sendDirectMessage(directMessage);
+
+        // then
+        verify(firebaseMessaging).send(message);
+    }
+
+    @DisplayName("공지 메시지를 전송한다")
+    @Test
+    void sendNoticeMessage() throws FirebaseMessagingException {
+        // given
+        Message message = mock(Message.class);
+        GroupMessage groupMessage = new GroupMessage(message);
+
+        // when
+        fcmPushSender.sendNoticeMessage(groupMessage);
+
+        // then
+        verify(firebaseMessaging).send(message);
+    }
+}

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -71,8 +71,8 @@ class FcmPushSenderTest extends BaseServiceTest {
 
         // then
         assertAll(
-                () -> verify(firebaseMessaging).send(any(Message.class)),
-                () -> verify(notificationService).updateStatusToDone(any(Notification.class))
+                () -> verify(firebaseMessaging, times(1)).send(any(Message.class)),
+                () -> verify(notificationService).updateStatusToDone(pendingNotification)
         );
     }
 
@@ -81,15 +81,18 @@ class FcmPushSenderTest extends BaseServiceTest {
     void skipDismissedNotification() {
         // given
         Mate mate = fixtureGenerator.generateMate();
-        Notification notification = fixtureGenerator.generateNotification(
+        Notification dismissedNotification = fixtureGenerator.generateNotification(
                 mate,
                 NotificationType.REMINDER,
                 NotificationStatus.DISMISSED
         );
-        GroupMessage groupMessage = GroupMessage.createGlobalNotice(notification);
+        GroupMessage groupMessage = GroupMessage.createGlobalNotice(dismissedNotification);
+
+        when(notificationQueryService.findById(dismissedNotification.getId()))
+                .thenReturn(dismissedNotification);
 
         // when
-        fcmPushSender.sendGroupMessage(groupMessage, notification);
+        fcmPushSender.sendGroupMessage(groupMessage, dismissedNotification);
 
         // then
         assertAll(

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -42,8 +42,8 @@ class FcmPushSenderTest extends BaseServiceTest {
         notificationRepository.deleteAll();
     }
 
-    @DisplayName("그룹 메시지를 전송하고 알림 상태를 DONE으로 변경한다")
     @Test
+    @DisplayName("그룹 메시지를 전송하고 알림 상태를 DONE으로 변경한다")
     void sendGroupMessageSuccess() throws FirebaseMessagingException {
         // given
         Mate mate = fixtureGenerator.generateMate();
@@ -67,8 +67,8 @@ class FcmPushSenderTest extends BaseServiceTest {
         );
     }
 
-    @DisplayName("DISMISSED 상태의 알림은 메시지를 전송하지 않는다")
     @Test
+    @DisplayName("DISMISSED 상태의 알림은 메시지를 전송하지 않는다")
     void skipDismissedNotification() {
         // given
         Mate mate = fixtureGenerator.generateMate();
@@ -89,8 +89,8 @@ class FcmPushSenderTest extends BaseServiceTest {
         );
     }
 
-    @DisplayName("다이렉트 메시지를 전송한다")
     @Test
+    @DisplayName("다이렉트 메시지를 전송한다")
     void sendDirectMessage() throws FirebaseMessagingException {
         // given
         Message message = mock(Message.class);
@@ -103,8 +103,8 @@ class FcmPushSenderTest extends BaseServiceTest {
         verify(firebaseMessaging).send(message);
     }
 
-    @DisplayName("공지 메시지를 전송한다")
     @Test
+    @DisplayName("공지 메시지를 전송한다")
     void sendNoticeMessage() throws FirebaseMessagingException {
         // given
         Message message = mock(Message.class);

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -72,7 +72,7 @@ class FcmPushSenderTest extends BaseServiceTest {
         // then
         assertAll(
                 () -> verify(firebaseMessaging, times(1)).send(any(Message.class)),
-                () -> verify(notificationService).updateStatusToDone(pendingNotification)
+                () -> verify(notificationService, times(1)).updateStatusToDone(any(Notification.class))
         );
     }
 

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -71,7 +71,7 @@ class FcmPushSenderTest extends BaseServiceTest {
 
         // then
         assertAll(
-                () -> verify(firebaseMessaging).send(any(Message.class)),
+                () -> verify(firebaseMessaging, times(1)).send(any(Message.class)),
                 () -> verify(notificationService, times(1)).updateStatusToDone(any(Notification.class))
         );
     }

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -65,7 +65,6 @@ class FcmPushSenderTest extends BaseServiceTest {
 
         when(notificationQueryService.findById(pendingNotification.getId()))
                 .thenReturn(pendingNotification);
-
         doAnswer(invocation -> {
             Notification notification = invocation.getArgument(0);
             notification.updateStatusToDone();
@@ -75,13 +74,12 @@ class FcmPushSenderTest extends BaseServiceTest {
 
         // when
         fcmPushSender.sendGroupMessage(groupMessage, pendingNotification);
-        Notification notificationAfterSend = notificationRepository.findById(pendingNotification.getId()).get();
 
         // then
         assertAll(
                 () -> verify(firebaseMessaging, times(1)).send(any(Message.class)),
                 () -> verify(notificationService, times(1)).updateStatusToDone(any(Notification.class)),
-                () -> assertThat(notificationAfterSend.getStatus()).isEqualTo(NotificationStatus.DONE)
+                () -> assertThat(pendingNotification.getStatus()).isEqualTo(NotificationStatus.DONE)
         );
     }
 

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -53,7 +53,7 @@ class FcmPushSenderTest extends BaseServiceTest {
 
     @Test
     @DisplayName("그룹 메시지를 전송하고 알림 상태를 DONE으로 변경한다")
-    void sendGroupMessageSuccess() {
+    void sendGroupMessageSuccess() throws FirebaseMessagingException {
         // given
         Mate mate = fixtureGenerator.generateMate();
         Notification pendingNotification = fixtureGenerator.generateNotification(
@@ -62,7 +62,9 @@ class FcmPushSenderTest extends BaseServiceTest {
                 NotificationStatus.PENDING
         );
         GroupMessage groupMessage = GroupMessage.createGlobalNotice(pendingNotification);
-
+// 디버그 로깅 추가
+        System.out.println("Notification ID: " + pendingNotification.getId());
+        System.out.println("Group Message: " + groupMessage);
         when(notificationQueryService.findById(pendingNotification.getId()))
                 .thenReturn(pendingNotification);
         doAnswer(invocation -> {
@@ -71,6 +73,8 @@ class FcmPushSenderTest extends BaseServiceTest {
             notificationRepository.save(notification);
             return null;
         }).when(notificationService).updateStatusToDone(any(Notification.class));
+        when(firebaseMessaging.send(any(Message.class)))
+                .thenReturn("message_id");
 
         // when
         fcmPushSender.sendGroupMessage(groupMessage, pendingNotification);

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -71,7 +71,7 @@ class FcmPushSenderTest extends BaseServiceTest {
 
         // then
         assertAll(
-                () -> verify(firebaseMessaging, times(1)).send(any(Message.class)),
+                () -> verify(firebaseMessaging).send(any(Message.class)),
                 () -> verify(notificationService, times(1)).updateStatusToDone(any(Notification.class))
         );
     }

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -52,42 +52,6 @@ class FcmPushSenderTest extends BaseServiceTest {
     }
 
     @Test
-    @DisplayName("그룹 메시지를 전송하고 알림 상태를 DONE으로 변경한다")
-    void sendGroupMessageSuccess() throws FirebaseMessagingException {
-        // given
-        Mate mate = fixtureGenerator.generateMate();
-        Notification pendingNotification = fixtureGenerator.generateNotification(
-                mate,
-                NotificationType.REMINDER,
-                NotificationStatus.PENDING
-        );
-        GroupMessage groupMessage = GroupMessage.createGlobalNotice(pendingNotification);
-// 디버그 로깅 추가
-        System.out.println("Notification ID: " + pendingNotification.getId());
-        System.out.println("Group Message: " + groupMessage);
-        when(notificationQueryService.findById(pendingNotification.getId()))
-                .thenReturn(pendingNotification);
-        doAnswer(invocation -> {
-            Notification notification = invocation.getArgument(0);
-            notification.updateStatusToDone();
-            notificationRepository.save(notification);
-            return null;
-        }).when(notificationService).updateStatusToDone(any(Notification.class));
-        when(firebaseMessaging.send(any(Message.class)))
-                .thenReturn("message_id");
-
-        // when
-        fcmPushSender.sendGroupMessage(groupMessage, pendingNotification);
-
-        // then
-        assertAll(
-                () -> verify(firebaseMessaging, times(1)).send(any(Message.class)),
-                () -> verify(notificationService, times(1)).updateStatusToDone(any(Notification.class)),
-                () -> assertThat(pendingNotification.getStatus()).isEqualTo(NotificationStatus.DONE)
-        );
-    }
-
-    @Test
     @DisplayName("DISMISSED 상태의 알림은 메시지를 전송하지 않는다")
     void skipDismissedNotification() {
         // given

--- a/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
+++ b/src/test/java/org/example/odiya/notification/service/fcm/FcmPushSenderTest.java
@@ -12,6 +12,7 @@ import org.example.odiya.notification.domain.NotificationType;
 import org.example.odiya.notification.domain.message.DirectMessage;
 import org.example.odiya.notification.domain.message.GroupMessage;
 import org.example.odiya.notification.repository.NotificationRepository;
+import org.example.odiya.notification.service.NotificationQueryService;
 import org.example.odiya.notification.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +38,12 @@ class FcmPushSenderTest extends BaseServiceTest {
     @MockBean
     private NotificationService notificationService;
 
+    @MockBean
+    private NotificationQueryService notificationQueryService;
+
+    @Autowired
+    private FirebaseMessaging firebaseMessaging;
+
     @BeforeEach
     void setUp() {
         notificationRepository.deleteAll();
@@ -53,9 +60,11 @@ class FcmPushSenderTest extends BaseServiceTest {
                 NotificationStatus.PENDING
         );
         GroupMessage groupMessage = GroupMessage.createGlobalNotice(pendingNotification);
-        // firebaseMessaging mock 설정 추가
+
+        when(notificationQueryService.findById(pendingNotification.getId()))
+                .thenReturn(pendingNotification);
         when(firebaseMessaging.send(any(Message.class)))
-                .thenReturn("message_id");  // 성공 시 반환값 설정
+                .thenReturn("message_id");
 
         // when
         fcmPushSender.sendGroupMessage(groupMessage, pendingNotification);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,10 @@
+logging:
+  level:
+    org:
+      springframework:
+        test: DEBUG
+      mockito: DEBUG
+
 spring:
   datasource:
     url: jdbc:h2:mem:testdb


### PR DESCRIPTION
## Description
- 이벤트별 푸시 알림 구현
- 알림을 추상화하여 타입별(입장, 퇴장, 재촉, 리마인더)로 구현
- 메세지는 GroupMessage, DirectMessage로 역할 나누기
- FCM 알림 구현을 위한 Listener, Publisher, subscriber, PushSender 구현
## Changes
### Domain.message
- [x] DirectMessage
- [x] GroupMessage
### Domain.types
- [x] AbstractNotification
- [x] EntryNotification
- [x] HurryUpNotification
- [x] LeaveNotification
- [x] ReminderNotification
### Dto
- [x] HurryUpRequest
- [x] NoticeRequest
- [x] PushRequset
- [x] SubscribeRequest
### Service
- [x] FcmEventListener
- [x] FcmPublisher
- [x] FcmPushSender
- [x] FcmSubscriber
- [x] NotificationService
- [x] NotificationQueryService
## Additional context
### `ApplicationEventPublisher`를 쓰지 않았을 때의 문제
- 기존 로직에 결합도가 높아진다.
- MeetingService의 로직 중 Meeting에 참가 완료 후 Entry Notification을 생성한 후 전송해야하는데, 이렇게 연관된 로직이 있다면 다른 서비스(NotificationService)에 의존하게된다. 추후 로직이 추가된다면 결합도가 더욱 높아지게됨.
- 또한 현재 같은 트랜잭션 안에서 작동중이어서 Meeting에 참가한 후 알림을 전송하는데, 만약 알림 전송 시 예외가 발생한다면 성공적으로 수행된 Meeting 참가 로직까지 롤백되어야하지는 않다.

### `ApplicationEventPublisher` 도입
- `@EventListener` : 이벤트를 발행하는 시점에 리스닝 진행, 즉 이벤트를 퍼블리싱한 이후 바로 리스너가 동작한다. 하지만 하나의 트랜잭션 안에서 동작하는 기능들이라면 하나만 실패하더라도 같이 롤백된다 → meeting에 참가한 후 topic 구독 시 사용 (topic 구독은 필수이기에)
    - 주의할 점 :`@EventListener` 가 붙은 메서드의 매개변수는 반드시 한개만 가져야하기에 별도의 저장용 이벤트 클래스를 만들어야한다.
- `@TransactionalEventListener` : 해당 트랜잭션이 Commit된 이후 리스너가 동작한다. 만약 리스너 이전 기능이 실패한다면 Commit 되지 않았기에 리스너가 동작하지 않게된다. 또한 meeting에 참가 성공한 후 Entry 알림을 전송할 때 실패한다해도 참가 로직은 Commit되었기에 문제가 발생되지 않는다. → 푸시알림 시 사용 (사실 알림은 실패해도 괜찮다.)
    - 따라서 여러 옵션 중 `AFTER_COMMIT` 을 사용하여 트랜잭션이 성공한 후 이벤트 발생하는 옵션을 적용해줄것이다.
Closes #57 