### PR TITLE
Feature/#60 Meeting 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/example/odiya/eta/domain/Eta.java
+++ b/src/main/java/org/example/odiya/eta/domain/Eta.java
@@ -20,7 +20,7 @@ public class Eta extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE)
     @JoinColumn(name = "mate_id")
     private Mate mate;
 

--- a/src/main/java/org/example/odiya/mate/domain/Mate.java
+++ b/src/main/java/org/example/odiya/mate/domain/Mate.java
@@ -6,6 +6,10 @@ import org.example.odiya.common.domain.BaseEntity;
 import org.example.odiya.meeting.domain.Location;
 import org.example.odiya.meeting.domain.Meeting;
 import org.example.odiya.member.domain.Member;
+import org.example.odiya.notification.domain.Notification;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -31,6 +35,10 @@ public class Mate extends BaseEntity {
 
     @Column
     private long estimatedTime;
+
+    @OneToMany(mappedBy = "mate", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Notification> notifications = new ArrayList<>();
 
     public Mate(Member member, Meeting meeting) {
         this.member = member;

--- a/src/main/java/org/example/odiya/mate/repository/MateRepository.java
+++ b/src/main/java/org/example/odiya/mate/repository/MateRepository.java
@@ -2,6 +2,7 @@ package org.example.odiya.mate.repository;
 
 import org.example.odiya.mate.domain.Mate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -11,5 +12,11 @@ public interface MateRepository extends JpaRepository<Mate, Long> {
 
     int countByMeetingId(Long meetingId);
 
-    Optional<Mate> findByMemberIdAndMeetingId(Long memberId, Long meetingId);
+    @Query("SELECT m " +
+            "FROM Mate m " +
+            "JOIN FETCH m.member " +
+            "JOIN FETCH m.meeting  " +
+            "WHERE m.meeting.id = :meetingId " +
+            "AND m.member.id = :memberId")
+    Optional<Mate> findByMeetingIdAndMemberId(Long memberId, Long meetingId);
 }

--- a/src/main/java/org/example/odiya/mate/service/MateQueryService.java
+++ b/src/main/java/org/example/odiya/mate/service/MateQueryService.java
@@ -38,4 +38,9 @@ public class MateQueryService {
     public int countByMeetingId(Long meetingId) {
         return mateRepository.countByMeetingId(meetingId);
     }
+
+    public Mate findByMemberIdAndMeetingId(Long memberId, Long meetingId) {
+        return mateRepository.findByMeetingIdAndMemberId(meetingId, memberId)
+                .orElseThrow(() -> new NotFoundException(MATE_NOT_FOUND_ERROR));
+    }
 }

--- a/src/main/java/org/example/odiya/mate/service/MateService.java
+++ b/src/main/java/org/example/odiya/mate/service/MateService.java
@@ -134,4 +134,13 @@ public class MateService {
         EtaStatus etaStatus = etaService.findEtaStatus(receiver);
         return etaStatus == EtaStatus.LATE;
     }
+
+    @Transactional
+    public void leaveMeeting(Long meetingId, Member member) {
+        Mate mate = mateQueryService.findByMemberIdAndMeetingId(meetingId, member.getId());
+        notificationService.sendLeaveNotification(mate);
+        notificationService.updateAllStatusToDismissedByMateIdAndSendAtAfterNow(mate.getId());
+        notificationService.unsubscribeTopic(mate.getMeeting(), member.getDeviceToken());
+        mateRepository.delete(mate);
+    }
 }

--- a/src/main/java/org/example/odiya/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/example/odiya/meeting/repository/MeetingRepository.java
@@ -19,7 +19,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "WHERE m.overdue = false " +
             "AND ((m.date < :date) " +
             "OR (m.date = :date AND m.time <= :time))")
-    @Modifying
+    @Modifying(clearAutomatically = true)
     int bulkUpdateOverdueStatus(
             @Param("date") LocalDate date,
             @Param("time") LocalTime time

--- a/src/main/java/org/example/odiya/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/odiya/notification/repository/NotificationRepository.java
@@ -5,7 +5,9 @@ import org.example.odiya.notification.domain.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Modifying;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -16,4 +18,13 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             " JOIN FETCH Member member on mate.member.id = member.id" +
             " WHERE noti.type = :type")
     List<Notification> findAllMeetingIdAndType(@Param("meetingId") Long meetingId, @Param("type") NotificationType type);
+
+    @Query("UPDATE Notification noti" +
+            " SET noti.status = 'DISMISSED'" +
+            " WHERE noti.mate.id = :mateId " +
+            " AND noti.sendAt > :now")
+    @Modifying(clearAutomatically = true)
+    void updateAllStatusToDismissedByMateIdAndSendAtAfterNow(long mateId, LocalDateTime now);
+
+    List<Notification> findAllByMateId(Long mateId);
 }

--- a/src/main/java/org/example/odiya/notification/service/NotificationService.java
+++ b/src/main/java/org/example/odiya/notification/service/NotificationService.java
@@ -9,7 +9,9 @@ import org.example.odiya.notification.domain.FcmTopic;
 import org.example.odiya.notification.domain.Notification;
 import org.example.odiya.notification.domain.NotificationType;
 import org.example.odiya.notification.domain.types.HurryUpNotification;
+import org.example.odiya.notification.domain.types.LeaveNotification;
 import org.example.odiya.notification.service.event.HurryUpEvent;
+import org.example.odiya.notification.service.event.LeaveEvent;
 import org.example.odiya.notification.service.event.PushEvent;
 import org.example.odiya.notification.service.event.SubscribeEvent;
 import org.example.odiya.notification.repository.NotificationRepository;
@@ -67,6 +69,13 @@ public class NotificationService {
         fcmPublisher.publishWithTransaction(new HurryUpEvent(this, sender, savedNotification));
     }
 
+    @Transactional
+    public void sendLeaveNotification(Mate mate) {
+        LeaveNotification leaveNotification = new LeaveNotification(mate);
+        Notification savedNotification = saveNotification(leaveNotification.toNotification());
+        fcmPublisher.publishWithTransaction(new LeaveEvent(this, mate, savedNotification));
+    }
+
     public void subscribeTopic(DeviceToken deviceToken, FcmTopic fcmTopic) {
         fcmPublisher.publishWithTransaction(new SubscribeEvent(this, deviceToken, fcmTopic));
     }
@@ -85,5 +94,9 @@ public class NotificationService {
                             notification.getMate().getMember().getDeviceToken()
                     ));
         }
+    }
+
+    public void updateAllStatusToDismissedByMateIdAndSendAtAfterNow(long mateId){
+        notificationRepository.updateAllStatusToDismissedByMateIdAndSendAtAfterNow(mateId, LocalDateTime.now());
     }
 }

--- a/src/main/java/org/example/odiya/notification/service/event/LeaveEvent.java
+++ b/src/main/java/org/example/odiya/notification/service/event/LeaveEvent.java
@@ -1,0 +1,43 @@
+package org.example.odiya.notification.service.event;
+
+import com.google.firebase.messaging.Message;
+import lombok.Getter;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.message.DirectMessage;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+
+@Getter
+public class LeaveEvent extends ApplicationEvent {
+
+    private final Mate leavingMate;
+    private final Notification notification;
+    private final List<DirectMessage> directMessages;
+
+    public LeaveEvent(Object source, Mate leavingMate, Notification notification) {
+        super(source);
+        this.leavingMate = leavingMate;
+        this.notification = notification;
+        this.directMessages = createMeetingLeaveNotice(leavingMate, notification);
+    }
+
+    private static List<DirectMessage> createMeetingLeaveNotice(Mate leavingMate, Notification notification) {
+        return leavingMate.getMeeting().getMates().stream()
+                .filter(mate -> !mate.getId().equals(leavingMate.getId())) // 퇴장하는 사람 제외
+                .map(mate -> new DirectMessage(Message.builder()
+                        .putData("type", notification.getType().name())
+                        .putData("name", leavingMate.getMember().getName())
+                        .putData("meetingId", leavingMate.getMeeting().getId().toString())
+                        .putData("title", String.format("%s님이 약속에서 나갔습니다.",
+                                leavingMate.getMember().getName()))
+                        .putData("body", String.format("%s님이 %s 약속에서 나갔습니다.",
+                                leavingMate.getMember().getName(), leavingMate.getMeeting().getName()))
+                        .setToken(mate.getMember().getDeviceToken().getValue())
+                        .build())
+                )
+                .toList();
+    }
+}

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmEventListener.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmEventListener.java
@@ -8,10 +8,7 @@ import org.example.odiya.notification.domain.FcmTopic;
 import org.example.odiya.notification.domain.Notification;
 import org.example.odiya.notification.domain.message.DirectMessage;
 import org.example.odiya.notification.domain.message.GroupMessage;
-import org.example.odiya.notification.service.event.HurryUpEvent;
-import org.example.odiya.notification.service.event.NoticeEvent;
-import org.example.odiya.notification.service.event.PushEvent;
-import org.example.odiya.notification.service.event.SubscribeEvent;
+import org.example.odiya.notification.service.event.*;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -20,6 +17,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -59,6 +57,22 @@ public class FcmEventListener {
         log.info("푸시 알림 전송 - id: {}, type: {}",
                 notification.getId(),
                 notification.getType());
+    }
+
+    @Async("fcmExecutor")
+    @EventListener
+    public void handleLeave(LeaveEvent event) {
+        Notification notification = event.getNotification();
+        List<DirectMessage> directMessages = event.getDirectMessages();
+
+        for (DirectMessage directMessage : directMessages) {
+            fcmPushSender.sendDirectMessage(directMessage);
+        }
+
+        log.info("퇴장 알림 전송 완료 - id: {}, type: {}, 수신자 수: {}",
+                notification.getId(),
+                notification.getType(),
+                directMessages.size());
     }
 
     @Async("fcmExecutor")

--- a/src/test/java/org/example/odiya/common/BaseTest/BaseServiceTest.java
+++ b/src/test/java/org/example/odiya/common/BaseTest/BaseServiceTest.java
@@ -1,6 +1,5 @@
 package org.example.odiya.common.BaseTest;
 
-import com.google.firebase.messaging.FirebaseMessaging;
 import org.example.odiya.common.Fixture.DtoGenerator;
 import org.example.odiya.common.Fixture.FixtureGenerator;
 import org.example.odiya.common.config.FixtureGeneratorConfig;

--- a/src/test/java/org/example/odiya/mate/repository/MateRepositoryTest.java
+++ b/src/test/java/org/example/odiya/mate/repository/MateRepositoryTest.java
@@ -70,12 +70,12 @@ class MateRepositoryTest extends BaseRepositoryTest {
 
     @Test
     @DisplayName("멤버와 약속으로 참여 정보 조회")
-    void findByMemberIdAndMeetingId_WhenExists_ReturnsMate() {
+    void findByMemberId_AndMeetingIdv1_WhenExists_ReturnsMate() {
         // Given
         Mate savedMate = fixtureGenerator.generateMate(meeting, member);
 
         // When
-        Optional<Mate> foundMate = mateRepository.findByMemberIdAndMeetingId(member.getId(), meeting.getId());
+        Optional<Mate> foundMate = mateRepository.findByMeetingIdAndMemberId(member.getId(), meeting.getId());
 
         // Then
         assertThat(foundMate).isPresent();
@@ -86,13 +86,13 @@ class MateRepositoryTest extends BaseRepositoryTest {
 
     @Test
     @DisplayName("존재하지 않는 참여 정보 조회")
-    void findByMemberIdAndMeetingId_WhenNotExists_ReturnsEmpty() {
+    void findByMemberId_AndMeetingIdv1_WhenNotExists_ReturnsEmpty() {
         // Given
         Long nonExistentMemberId = 999L;
         Long nonExistentMeetingId = 999L;
 
         // When
-        Optional<Mate> foundMate = mateRepository.findByMemberIdAndMeetingId(nonExistentMemberId, nonExistentMeetingId);
+        Optional<Mate> foundMate = mateRepository.findByMeetingIdAndMemberId(nonExistentMemberId, nonExistentMeetingId);
 
         // Then
         assertThat(foundMate).isEmpty();

--- a/src/test/java/org/example/odiya/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/org/example/odiya/meeting/service/MeetingServiceTest.java
@@ -122,7 +122,6 @@ class MeetingServiceTest extends BaseServiceTest {
         // Then
         assertThat(response).isNotNull();
         assertThat(response.getMeetings()).isNotEmpty();
-        assertThat(response.getMeetings().size()).isGreaterThan(0);
     }
 
     @Test
@@ -182,7 +181,7 @@ class MeetingServiceTest extends BaseServiceTest {
     }
 
     @Test
-    @DisplayName("모임 시간이 지난 경우 예외를 발생시킨다")
+    @DisplayName("약속 시간이 지난 경우 예외를 발생시킨다")
     void throwExceptionWhenMeetingIsOverdue() {
         // Given
         Meeting overdueMeeting = fixtureGenerator.generateOverdueMeeting();

--- a/src/test/java/org/example/odiya/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/org/example/odiya/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,55 @@
+package org.example.odiya.notification.repository;
+
+import org.example.odiya.common.BaseTest.BaseRepositoryTest;
+import org.example.odiya.mate.domain.Mate;
+import org.example.odiya.meeting.domain.Meeting;
+import org.example.odiya.member.domain.Member;
+import org.example.odiya.notification.domain.Notification;
+import org.example.odiya.notification.domain.NotificationStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    @DisplayName("특정 Mate의 미래 알림들의 상태를 DISMISSED로 변경한다")
+    void updateAllStatusToDismissedByMateIdAndSendAtAfterNow_Success() {
+        // Given
+        Member member = fixtureGenerator.generateMember();
+        Meeting meeting = fixtureGenerator.generateMeeting();
+        Mate mate = fixtureGenerator.generateMate(meeting, member);
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime futureTime = now.plusHours(1);
+
+        fixtureGenerator.generateNotification(mate, futureTime, NotificationStatus.PENDING);
+        fixtureGenerator.generateNotification(mate, futureTime.plusHours(1), NotificationStatus.PENDING);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        notificationRepository.updateAllStatusToDismissedByMateIdAndSendAtAfterNow(mate.getId(), now);
+
+        // Then
+        List<Notification> notifications = notificationRepository.findAllByMateId(mate.getId());
+        assertThat(notifications).hasSize(2);
+        notifications.stream()
+                .filter(noti -> noti.getSendAt().isAfter(now))
+                .forEach(noti -> assertThat(noti.getStatus()).isEqualTo(NotificationStatus.DISMISSED));
+        notifications.stream()
+                .filter(noti -> noti.getSendAt().isBefore(now))
+                .forEach(noti -> assertThat(noti.getStatus()).isEqualTo(NotificationStatus.PENDING));
+    }
+
+
+}

--- a/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
+++ b/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
@@ -4,6 +4,7 @@ import org.example.odiya.common.BaseTest.BaseServiceTest;
 import org.example.odiya.mate.domain.Mate;
 import org.example.odiya.meeting.domain.Meeting;
 import org.example.odiya.member.domain.DeviceToken;
+import org.example.odiya.member.domain.Member;
 import org.example.odiya.notification.domain.FcmTopic;
 import org.example.odiya.notification.domain.Notification;
 import org.example.odiya.notification.domain.NotificationStatus;
@@ -11,6 +12,7 @@ import org.example.odiya.notification.domain.NotificationType;
 import org.example.odiya.notification.domain.types.HurryUpNotification;
 import org.example.odiya.notification.repository.NotificationRepository;
 import org.example.odiya.notification.service.event.HurryUpEvent;
+import org.example.odiya.notification.service.event.LeaveEvent;
 import org.example.odiya.notification.service.event.SubscribeEvent;
 import org.example.odiya.notification.service.fcm.FcmPublisher;
 import org.junit.jupiter.api.BeforeEach;
@@ -147,5 +149,26 @@ class NotificationServiceTest extends BaseServiceTest {
 
         // then
         verify(fcmPublisher).publish(any(SubscribeEvent.class));
+    }
+
+    @Test
+    @DisplayName("퇴장 알림 전송에 성공한다")
+    void sendLeaveNotification_Success() {
+        // Given
+        Member newMember = fixtureGenerator.generateMember();
+        Meeting newMeeting = fixtureGenerator.generateMeeting();
+        Mate mate = fixtureGenerator.generateMate(newMeeting, newMember);
+
+        Member otherMember1 = fixtureGenerator.generateMember();
+        Member otherMember2 = fixtureGenerator.generateMember();
+        fixtureGenerator.generateMate(newMeeting, otherMember1);
+        fixtureGenerator.generateMate(newMeeting, otherMember2);
+
+        // When
+        notificationService.sendLeaveNotification(mate);
+
+        // Then
+        verify(fcmPublisher).publishWithTransaction(any(LeaveEvent.class));
+        assertThat(notificationRepository.findAll()).hasSize(1);
     }
 }

--- a/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
+++ b/src/test/java/org/example/odiya/notification/service/NotificationServiceTest.java
@@ -152,7 +152,7 @@ class NotificationServiceTest extends BaseServiceTest {
     }
 
     @Test
-    @DisplayName("퇴장 알림 전송에 성공한다")
+    @DisplayName("약속 퇴장 이벤트를 발행한다")
     void sendLeaveNotification_Success() {
         // Given
         Member newMember = fixtureGenerator.generateMember();


### PR DESCRIPTION
## Description
- Meeting 탈퇴 기능 구현
- Mate를 삭제할 때 관련된 Eta와 Notification도 함께 삭제되어야하고, 해당 Meeting에 대한 토픽 구독 해제, Leave 푸쉬 알림 구현한다.
## Changes
### Service
- [x] NotificationService
- [x] MateService
- [x] FcmEventListener
### Repository
- [x] MateRepository
### Domain
- [x] Eta
- [x] Mate
- [x] Notification
- [x] LeaveEvent
### Test
- [x] NotificationServiceTest
- [x] MateServiceTest
- [x] NotificationRepositoryTest
## Additional context
### `@Modifying(clearAutomatically = true)` 사용

- `@Modifying` 어노테이션에는 clearAutomatically, flushAutomatically 두 가지 속성이 있으며, 두 속성 모두 default 값은 false이다.
- 만약 false로 두고 해당 메서드를 실행한다면, update문이 실행되었지만 곧바로 조회했을경우 update 되기 전의 값을 조회할 수도 있다.
- 이때 문제되는 부분은 Persistent, 즉 영속 상태이다. 객체를 저장한 상태라고도 하는데, save() 메서드를 통해 ID를 할당하며 이후 트랜잭션이 끝날때까지 모든 변경 사항을 감지하고 동기화하는 상태이다.
- 하지만 Persistent 상태에선 하이버네이트가 한 트랜잭션 내에 불필요한 쿼리를 줄여주는 역할을 해주는데, 흔히 1차 캐시라고 부르는 영속성 컨텍스트가 해당 인스턴스를 이미 담고있기에 SELECT 요청을 하면 DB에서 값을 가져오는 게 아닌 영속성 컨텍스트(Persistent Context)에 저장된 인스턴스를 반환한다. 결론적으로 update 로직 이전의 값을 가져오게 되는 것!
- 따라서 **`clearAutomatically = true`** 옵션을 통해 `@Modifying` 어노테이션이 적용된 쿼리를 실행한 후 영속성 컨텍스트에 담겨있는 인스턴스를 clear하여 곧바로 SELECT 문이 실행되면 DB에서 값을 가져오기에 원하는 값을 가져올 수 있게된다.
Closes #60 