### PR TITLE
Feature/#68 로그인 유무 검증 어노테이션 사용으로 인한 스웨거 호출 문제 해결

### DIFF
--- a/src/main/java/org/example/odiya/mate/controller/MateController.java
+++ b/src/main/java/org/example/odiya/mate/controller/MateController.java
@@ -1,6 +1,7 @@
 package org.example.odiya.mate.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class MateController {
 
     @Operation(summary = "약속 참여 API", description = "사용자가 약속에 참여합니다.")
     @PostMapping("/join")
-    public ResponseEntity<MateJoinResponse> joinMeeting(@AuthMember Member member,
+    public ResponseEntity<MateJoinResponse> joinMeeting(@Parameter(hidden = true) @AuthMember Member member,
                                                         @Valid @RequestBody MateJoinRequest request) {
         MateJoinResponse mateJoinResponse = mateService.joinMeeting(member, request);
         return ResponseEntity
@@ -37,7 +38,7 @@ public class MateController {
 
     @Operation(summary = "참여자 재촉 API", description = "참여자가 약속 참여자들을 재촉합니다.")
     @PostMapping("/hurry-up")
-    public ResponseEntity<Void> hurryUp(@AuthMember Member member,
+    public ResponseEntity<Void> hurryUp(@Parameter(hidden = true) @AuthMember Member member,
                                         @Valid @RequestBody HurryUpRequest request) {
         mateService.hurryUpMate(member, request);
         return ResponseEntity

--- a/src/main/java/org/example/odiya/meeting/controller/MeetingController.java
+++ b/src/main/java/org/example/odiya/meeting/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package org.example.odiya.meeting.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class MeetingController {
 
     @Operation(summary = "약속 생성 API", description = "사용자가 약속을 생성합니다.")
     @PostMapping
-    public ResponseEntity<MeetingCreateResponse> createMeeting(@AuthMember Member member,
+    public ResponseEntity<MeetingCreateResponse> createMeeting(@Parameter(hidden = true) @AuthMember Member member,
                                                                @Valid @RequestBody MeetingCreateRequest request) {
         MeetingCreateResponse meetingCreateResponse = meetingService.createMeeting(member, request);
         return ResponseEntity
@@ -37,7 +38,7 @@ public class MeetingController {
 
     @Operation(summary = "약속 전체 조회 API", description = "사용자가 자신이 속한 약속리스트를 전체 조회합니다.")
     @GetMapping("/list")
-    public ResponseEntity<MeetingListResponse> getMyMeetingList(@AuthMember Member member) {
+    public ResponseEntity<MeetingListResponse> getMyMeetingList(@Parameter(hidden = true) @AuthMember Member member) {
         MeetingListResponse myMeetingList = meetingService.getMyMeetingList(member);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -46,7 +47,7 @@ public class MeetingController {
 
     @Operation(summary = "약속 상세 조회 API", description = "사용자가 자신이 속한 약속을 상세 조회합니다.")
     @GetMapping("/{id}")
-    public ResponseEntity<MeetingDetailResponse> getMeetingDetail(@AuthMember Member member,
+    public ResponseEntity<MeetingDetailResponse> getMeetingDetail(@Parameter(hidden = true) @AuthMember Member member,
                                                                   @PathVariable("id") Long meetingId) {
         MeetingDetailResponse meetingDetail = meetingService.getMeetingDetail(member, meetingId);
         return ResponseEntity
@@ -56,9 +57,8 @@ public class MeetingController {
 
     @Operation(summary = "참여자 도착 예정 시간 업데이트 API", description = "해당 약속의 모든 참여자들의 도착 예정 시간을 업데이트합니다.")
     @PutMapping("/{id}/eta")
-    public ResponseEntity<Void> updateMeetingEta(
-            @AuthMember Member member,
-            @PathVariable("id") Long meetingId) {
+    public ResponseEntity<Void> updateMeetingEta(@Parameter(hidden = true) @AuthMember Member member,
+                                                 @PathVariable("id") Long meetingId) {
         meetingService.updateEtaForMeetingMates(meetingId, member.getId());
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/org/example/odiya/notification/service/fcm/FcmEventListener.java
+++ b/src/main/java/org/example/odiya/notification/service/fcm/FcmEventListener.java
@@ -36,7 +36,7 @@ public class FcmEventListener {
                 request.getDeviceToken().getValue());
     }
 
-    @Async("fcmAsyncExecutor")
+    @Async("fcmExecutor")
     @EventListener
     public void handleUnSubscribe(SubscribeEvent request) {
         FcmTopic topic = request.getFcmTopic();


### PR DESCRIPTION
## Description
- 로그인 유무 검증 어노테이션 사용으로 인한 스웨거 호출 문제 해결
- 지금의 방식은 컨트롤러 메서드의 파라미터에 @AuthMember 어노테이션을 통해 로그인된 Member 객체를 파라미터로 받고 있었다. 하지만 스웨거에서 api 호출 시 실제로 클라이언트가 신경쓸 필요가 없는 파라미터인데도  requestBody에 Member 객체를 전부 넣어줘야 호출(테스트)가 가능하여 사실상 스웨거를 쓸 수 없게 되었다. 
- 따라서 @Parameter(hidden = true) 를 @AuthMember 어노테이션 옆에 추가하여 스웨거에서 노출되지 않게끔 바꾼다.
## Changes
- [x] MeetingController
- [x] MateController
## Additional context
1. 이전 스웨거 호출 시

![Image](https://github.com/user-attachments/assets/d53cd8c0-4a0c-4cba-ba75-143198db9f2c)

2. 해결 후 스웨거 호출 시

![Image](https://github.com/user-attachments/assets/557298b7-2727-4ffa-a0eb-7cfdd54757a7)

Closes #68 