### PR TITLE
Feature/#70 관리자 권한을 추가하여 관리자 전용 호출 API를 생성한다.

### DIFF
--- a/src/main/java/org/example/odiya/apicall/controller/ApiCallController.java
+++ b/src/main/java/org/example/odiya/apicall/controller/ApiCallController.java
@@ -2,16 +2,19 @@ package org.example.odiya.apicall.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.odiya.apicall.domain.ApiCall;
+import org.example.odiya.apicall.domain.ClientType;
+import org.example.odiya.apicall.dto.request.ClientStatusUpdateRequest;
 import org.example.odiya.apicall.dto.response.ApiCallCountResponse;
+import org.example.odiya.apicall.dto.response.ClientStatusResponse;
+import org.example.odiya.apicall.dto.response.ClientStatusResponses;
 import org.example.odiya.apicall.service.ApiCallService;
 import org.example.odiya.apicall.util.ClientTypeMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "ApiCall API", description = "외부 API 호출 관련 API")
 @PreAuthorize("hasAuthority('ROLE_ADMIN')")
@@ -27,5 +30,35 @@ public class ApiCallController {
     public ResponseEntity<ApiCallCountResponse> countApiCall(@PathVariable String clientName) {
         ApiCallCountResponse apiCallCountResponse = apiCallService.returnApiCountResponse(ClientTypeMapper.from(clientName));
         return ResponseEntity.ok(apiCallCountResponse);
+    }
+
+    @Operation(summary = "API 클라이언트 상태 조회 API", description = "특정 클라이언트의 활성화/비활성화 상태와 API 호출 횟수를 조회합니다.")
+    @GetMapping("/status/{clientName}")
+    public ResponseEntity<ClientStatusResponse> getClientStatus(@PathVariable String clientName) {
+        ClientType clientType = ClientTypeMapper.from(clientName);
+        ApiCall apiCall = apiCallService.findOrSaveTodayApiCallByClientType(clientType);
+
+        ClientStatusResponse response = new ClientStatusResponse(
+                clientType.name(),
+                apiCall.getCount(),
+                apiCall.getEnabled()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "모든 API 클라이언트 상태 조회 API", description = "모든 클라이언트의 활성화/비활성화 상태와 API 호출 횟수를 조회합니다.")
+    @GetMapping("/status")
+    public ResponseEntity<ClientStatusResponses> getAllClientStatus() {
+        ClientStatusResponses responses = apiCallService.findAllClientStatuses();
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "API 클라이언트 상태 변경 API", description = "특정 클라이언트의 활성화/비활성화 상태를 변경합니다.")
+    @PatchMapping("/status/{clientName}")
+    public ResponseEntity<ClientStatusResponse> updateClientStatus(@PathVariable String clientName,
+                                                                   @RequestBody @Valid ClientStatusUpdateRequest request) {
+        ClientType clientType = ClientTypeMapper.from(clientName);
+        ClientStatusResponse response = apiCallService.updateClientStatus(clientType, request.enabled());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/example/odiya/apicall/controller/ApiCallController.java
+++ b/src/main/java/org/example/odiya/apicall/controller/ApiCallController.java
@@ -7,14 +7,16 @@ import org.example.odiya.apicall.dto.response.ApiCallCountResponse;
 import org.example.odiya.apicall.service.ApiCallService;
 import org.example.odiya.apicall.util.ClientTypeMapper;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "ApiCall API", description = "외부 API 호출 관련 API")
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
 @RestController
-@RequestMapping("/admin/api-call")
+@RequestMapping("/admin/api/api-call")
 @RequiredArgsConstructor
 public class ApiCallController {
 

--- a/src/main/java/org/example/odiya/apicall/domain/ApiCall.java
+++ b/src/main/java/org/example/odiya/apicall/domain/ApiCall.java
@@ -46,4 +46,8 @@ public class ApiCall extends BaseEntity {
     public void markAsDisabled() {
         this.enabled = false;
     }
+
+    public void markAsEnabled() {
+        this.enabled = true;
+    }
 }

--- a/src/main/java/org/example/odiya/apicall/dto/request/ClientStatusUpdateRequest.java
+++ b/src/main/java/org/example/odiya/apicall/dto/request/ClientStatusUpdateRequest.java
@@ -1,0 +1,12 @@
+package org.example.odiya.apicall.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ClientStatusUpdateRequest(
+
+        @Schema(description = "클라이언트 사용 가능 여부 업데이트", example = "false")
+        @NotNull
+        boolean enabled
+) {
+}

--- a/src/main/java/org/example/odiya/apicall/dto/response/ClientStatusResponse.java
+++ b/src/main/java/org/example/odiya/apicall/dto/response/ClientStatusResponse.java
@@ -1,0 +1,24 @@
+package org.example.odiya.apicall.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.example.odiya.apicall.domain.ApiCall;
+
+public record ClientStatusResponse(
+
+        @Schema(description = "클라이언트 이름", type = "string", example = "google")
+        String clientName,
+
+        @Schema(description = "클라이언트 API 호출 횟수", type = "string", example = "20")
+        int apiCallCount,
+
+        @Schema(description = "클라이언트 API 사용 가능 여부", type = "string", example = "true")
+        boolean isAvailable
+) {
+    public static ClientStatusResponse from(ApiCall apiCall) {
+        return new ClientStatusResponse(
+                apiCall.getClientType().name(),
+                apiCall.getCount(),
+                apiCall.getEnabled()
+        );
+    }
+}

--- a/src/main/java/org/example/odiya/apicall/dto/response/ClientStatusResponses.java
+++ b/src/main/java/org/example/odiya/apicall/dto/response/ClientStatusResponses.java
@@ -1,0 +1,19 @@
+package org.example.odiya.apicall.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.example.odiya.apicall.domain.ApiCall;
+import java.util.List;
+
+public record ClientStatusResponses(
+
+        @Schema(description = "ClientStatusResponse를 담은 리스트")
+        List<ClientStatusResponse> clientStatuses
+) {
+    public static ClientStatusResponses from(List<ApiCall> apiCalls) {
+        List<ClientStatusResponse> responses = apiCalls.stream()
+                .map(ClientStatusResponse::from)
+                .toList();
+
+        return new ClientStatusResponses(responses);
+    }
+}

--- a/src/main/java/org/example/odiya/common/argumentresolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/org/example/odiya/common/argumentresolver/AuthMemberArgumentResolver.java
@@ -12,7 +12,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import static org.example.odiya.common.exception.type.ErrorType.NO_AUTHORIZATION_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.NO_AUTHENTICATION_ERROR;
 
 @Component
 public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -33,6 +33,6 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
             return authentication.getPrincipal();
         }
 
-        throw new UnauthorizedException(NO_AUTHORIZATION_ERROR);
+        throw new UnauthorizedException(NO_AUTHENTICATION_ERROR);
     }
 }

--- a/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
+++ b/src/main/java/org/example/odiya/common/exception/type/ErrorType.java
@@ -19,8 +19,10 @@ public enum ErrorType {
     COOKIE_NOT_FOUND_ERROR("COOKIE_40100", "쿠키가 존재하지 않습니다."),
 
     // Auth
-    NO_AUTHORIZATION_ERROR("AUTH_40100", "인증이 없는 사용자입니다."),
+    NO_AUTHENTICATION_ERROR("AUTH_40100", "인증이 없는 사용자입니다."),
     PASSWORD_NOT_MATCH_ERROR("AUTH_40101", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    ADMIN_AUTH_ERROR("AUTH_40300", "관리자 권한이 필요합니다."),
+    NO_AUTHORIZATION_ERROR("AUTH_40301", "접근 권한이 없습니다."),
 
     // Resource
     NO_RESOURCE_ERROR("RESOURCE_40000", "해당 리소스를 찾을 수 없습니다."),

--- a/src/main/java/org/example/odiya/common/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/example/odiya/common/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package org.example.odiya.common.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.odiya.common.exception.ApiException;
+import org.example.odiya.common.exception.ForbiddenException;
+import org.example.odiya.common.exception.type.ErrorType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static org.example.odiya.common.exception.type.ErrorType.NO_AUTHORIZATION_ERROR;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ApiException apiException = new ForbiddenException(NO_AUTHORIZATION_ERROR);
+        setResponse(response, apiException);
+    }
+
+    private void setResponse(HttpServletResponse response, ApiException apiException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        ErrorType errorType = apiException.getErrorType();
+        int status = apiException.getHttpStatus().value();
+        response.setStatus(status);
+
+        response.getWriter().println(
+                "{\"status\" : \"" + status + "\"," +
+                        "\"errorCode\" : \"" + errorType.getErrorCode() + "\"," +
+                        "\"message\" : \"" + errorType.getMessage() + "\"}");
+    }
+}

--- a/src/main/java/org/example/odiya/common/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/org/example/odiya/common/security/jwt/filter/JwtExceptionFilter.java
@@ -24,12 +24,12 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request,
             HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+            FilterChain filterChain) throws IOException {
         try {
             filterChain.doFilter(request, response);
         } catch (SecurityException e) {
             log.error("FilterException throw SecurityException Exception : {}", e.getMessage());
-            setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, ErrorType.NO_AUTHORIZATION_ERROR);
+            setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, ErrorType.NO_AUTHENTICATION_ERROR);
         } catch (MalformedJwtException e) {
             log.error("FilterException throw MalformedJwtException Exception : {}", e.getMessage());
             setErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, ErrorType.TOKEN_MALFORMED_ERROR);

--- a/src/main/java/org/example/odiya/common/security/jwt/provider/JwtProvider.java
+++ b/src/main/java/org/example/odiya/common/security/jwt/provider/JwtProvider.java
@@ -6,22 +6,29 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.odiya.common.exception.UnauthorizedException;
 import org.example.odiya.member.domain.Member;
+import org.example.odiya.member.domain.MemberRole;
 import org.example.odiya.member.service.MemberQueryService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
-import static org.example.odiya.common.exception.type.ErrorType.TOKEN_EXPIRED_ERROR;
-import static org.example.odiya.common.exception.type.ErrorType.TOKEN_MALFORMED_ERROR;
+import static org.example.odiya.common.exception.type.ErrorType.*;
 
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtProvider {
@@ -33,7 +40,8 @@ public class JwtProvider {
     public int validityInMilliseconds;
 
     public String generateJwtToken(final String email) {
-        Claims claims = createClaims(email);
+        Member member = memberqueryService.findExistingMemberByEmail(email);
+        Claims claims = createClaims(email, member.getRole());
         Date now = new Date();
         long expiredDate = calculateExpirationDate(now);
         SecretKey secretKey = generateKey();
@@ -47,8 +55,10 @@ public class JwtProvider {
     }
 
     // JWT claims 생성
-    private Claims createClaims(final String email) {
-        return Jwts.claims().setSubject(String.valueOf(email));
+    private Claims createClaims(final String email, final MemberRole role) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(email));
+        claims.put("role", role.name());
+        return claims;
     }
 
     // JWT 만료 시간 계산
@@ -63,6 +73,11 @@ public class JwtProvider {
 
     // 토큰의 유효성 검사
     public void isValidToken(final String jwtToken) {
+        if (jwtToken == null || jwtToken.isEmpty()) {
+            log.warn("토큰이 null이거나 비어 있습니다.");
+            throw new UnauthorizedException(TOKEN_NOT_INCLUDED_ERROR);
+        }
+
         try {
             SecretKey secretKey = generateKey();
             Jwts.parserBuilder()
@@ -90,8 +105,12 @@ public class JwtProvider {
     }
 
     private void setContextHolder(String jwtToken, Member loginMember) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + loginMember.getRole().name()));
+        log.debug("인증 정보 설정: email={}, role={}, authorities={}",
+                loginMember.getEmail(), loginMember.getRole(), authorities);
         UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(loginMember, jwtToken, Collections.emptyList());
+                new UsernamePasswordAuthenticationToken(loginMember, jwtToken, authorities);
 
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
     }
@@ -107,5 +126,20 @@ public class JwtProvider {
                 .getBody();
 
         return claims.getSubject();
+    }
+
+    // 토큰에서 role 얻기
+    public MemberRole getRoleFromToken(final String jwtToken) {
+        SecretKey secretKey = generateKey();
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(jwtToken)
+                .getBody();
+
+        MemberRole role = MemberRole.valueOf(claims.get("role", String.class));
+        log.info("role: {}", role);
+        return role;
     }
 }

--- a/src/main/java/org/example/odiya/member/domain/Member.java
+++ b/src/main/java/org/example/odiya/member/domain/Member.java
@@ -31,6 +31,10 @@ public class Member extends BaseEntity {
     @Embedded
     private DeviceToken deviceToken;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private MemberRole role = MemberRole.USER;
+
     @OneToMany(mappedBy = "member")
     @Builder.Default
     private List<Mate> mates = new ArrayList<>();

--- a/src/main/java/org/example/odiya/member/domain/MemberRole.java
+++ b/src/main/java/org/example/odiya/member/domain/MemberRole.java
@@ -1,0 +1,5 @@
+package org.example.odiya.member.domain;
+
+public enum MemberRole {
+    ADMIN, USER
+}


### PR DESCRIPTION
## Description
- 관리자 권한을 추가하여 관리자 전용 호출 API를 생성한다.
## Changes
### Domain
- [x] Member
- [x] MemberRole
### Controller
- [x] ApiCallController
### Security
- [x] SecurityConfig
- [x] CustomAccessDeniedHandler
- [x] JwtProvider
### DTO
- [x] ClientStatusResponse
- [x] ClientStatusResponses
### Service
- [x] ApiCallService
## Additional context
- Security Config의 requestMatchers(), .hasAnyAuthority을 이용해서 일반 경로(/api/**)는 "ROLE_USER", "ROLE_ADMIN"만 접근할 수 있게하고, 관리자 전용 경로(/admin/api/**)는 .hasAuthority()를 이용하여 "ROLE_ADMIN"만 접근할 수 있게한다.
Closes #70 